### PR TITLE
Restructure model core

### DIFF
--- a/konrad/atmosphere.py
+++ b/konrad/atmosphere.py
@@ -9,9 +9,6 @@ from xarray import Dataset, DataArray
 
 from konrad import constants
 from konrad import utils
-from konrad.convection import (Convection, HardAdjustment)
-from konrad.lapserate import (LapseRate, MoistLapseRate)
-from konrad.upwelling import (Upwelling, NoUpwelling)
 
 
 __all__ = [
@@ -38,61 +35,9 @@ class Atmosphere(Dataset):
         'CCl4',
     ]
 
-    def __init__(self, convection=None, lapse=None,
-                 upwelling=None, **kwargs):
-        """Create an atmosphere model.
-
-       Parameters:
-             convection (konrad.humidity.Convection): Convection scheme.
-                Defaults to ``konrad.convection.HardAdjustment``.
-             lapse (konrad.lapse.LapseRate): Lapse rate handler.
-                Defaults to ``konrad.lapserate.MoistLapseRate``.
-        """
-        # Initialize ``xarray.Dataset`` with given positional args and kwargs.
-        super().__init__(**kwargs)
-
-        # Check input types.
-        convection = utils.return_if_type(convection, 'convection',
-                                          Convection, HardAdjustment())
-
-        lapse = utils.return_if_type(lapse, 'lapse',
-                                     LapseRate, MoistLapseRate())
-
-        upwelling = utils.return_if_type(upwelling, 'upwelling',
-                                         Upwelling, NoUpwelling())
-
-        # Set additional attributes for the Atmosphere object. They can be
-        # accessed through point notation but do not need to be of type
-        # ``xarrayy.DataArray``.
-        self.attrs.update({
-            'convection': convection,
-            'lapse': lapse,
-            'upwelling': upwelling,
-        })
-
-    def adjust(self, heatingrate, timestep, surface, **kwargs):
-        """Adjust temperature according to given heating rates.
-
-        Parameters:
-            heatingrate (ndarray): Radiative heatingrate [K/day].
-            timestep (float): Timestep width [day].
-        """
-        # Caculate critical lapse rate.
-        lapse = self.lapse.get(self)
-
-        # Apply heatingrates to temperature profile.
-        self['T'] += heatingrate * timestep
-
-        # Convective adjustment
-        self.convection.stabilize(atmosphere=self, lapse=lapse,
-                                  timestep=timestep, surface=surface)
-
-        # Upwelling induced cooling
-        self.upwelling.cool(atmosphere=self, radheat=heatingrate[0, :],
-                            timestep=timestep)
-
-        # Calculate the geopotential height field.
-        self.calculate_height()
+    def __init__(self, *args, **kwargs):
+        """Atmosphere component. """
+        super().__init__(*args, **kwargs)
 
     def create_variable(self, name, data=None, dims=None):
         """Createa a variable entry in the dataframe."""

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -104,14 +104,6 @@ class RCE:
         """
         return self.niter * 24 * self.timestep
 
-    def calculate_heatingrates(self):
-        """Use the radiation sub-model to calculate heatingrates."""
-        self.heatingrates = self.radiation.get_heatingrates(
-            atmosphere=self.atmosphere,
-            surface=self.surface,
-            cloud=self.cloud,
-            )
-
     def is_converged(self):
         """Check if the atmosphere is in radiative-convective equilibrium.
 
@@ -196,12 +188,12 @@ class RCE:
                 # All other iterations are only logged in DEBUG level.
                 logger.debug(f'Enter iteration {self.niter}.')
 
-            # Adjust the solar angle according to current time.
             self.radiation.adjust_solar_angle(self.get_hours_passed() / 24)
-
-            # Caculate shortwave, longwave and net heatingrates.
-            # Afterwards, they are accesible throug ``self.heatingrates``.
-            self.calculate_heatingrates()
+            self.heatingrates = self.radiation.get_heatingrates(
+                atmosphere=self.atmosphere,
+                surface=self.surface,
+                cloud=self.cloud,
+            )
 
             # Apply heatingrates/fluxes to the the surface.
             self.surface.adjust(

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -34,7 +34,7 @@ class RCE:
         >>> rce.run()
     """
     def __init__(self, atmosphere, radiation=None, humidity=None, surface=None,
-                 cloud=None, convection=None, lapse=None, upwelling=None,
+                 cloud=None, convection=None, lapserate=None, upwelling=None,
                  outfile=None, experiment='', timestep=1, delta=0.01,
                  writeevery=1, max_iterations=5000):
         """Set-up a radiative-convective model.
@@ -51,7 +51,7 @@ class RCE:
                 Defaults to ``konrad.cloud.ClearSky``.
             convection (konrad.humidity.Convection): Convection scheme.
                 Defaults to ``konrad.convection.HardAdjustment``.
-            lapse (konrad.lapse.LapseRate): Lapse rate handler.
+            lapserate (konrad.lapse.LapseRate): Lapse rate handler.
                 Defaults to ``konrad.lapserate.MoistLapseRate``.
             upwelling (konrad.upwelling.Upwelling):
                 TODO(sally): Please fill in doc.
@@ -84,8 +84,8 @@ class RCE:
         self.convection = utils.return_if_type(convection, 'convection',
                                           Convection, HardAdjustment())
 
-        self.lapse = utils.return_if_type(lapse, 'lapse',
-                                     LapseRate, MoistLapseRate())
+        self.lapserate = utils.return_if_type(lapserate, 'lapserate',
+                                              LapseRate, MoistLapseRate())
 
         self.upwelling = utils.return_if_type(upwelling, 'upwelling',
                                          Upwelling, NoUpwelling())
@@ -234,7 +234,7 @@ class RCE:
             T = self.atmosphere['T'].values.copy()
 
             # Caculate critical lapse rate.
-            lapse = self.lapse.get(self.atmosphere)
+            critical_lapserate = self.lapserate.get(self.atmosphere)
 
             # Apply heatingrates to temperature profile.
             self.atmosphere['T'] += (self.heatingrates['net_htngrt'] *
@@ -243,7 +243,7 @@ class RCE:
             # Convective adjustment
             self.convection.stabilize(
                 atmosphere=self.atmosphere,
-                lapse=lapse,
+                lapse=critical_lapserate,
                 timestep=self.timestep,
                 surface=self.surface,
             )

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -3,6 +3,7 @@
 """
 import logging
 from datetime import datetime
+from numbers import Number
 
 import numpy as np
 
@@ -56,7 +57,10 @@ class RCE:
                 TODO(sally): Please fill in doc.
             outfile (str): netCDF4 file to store output.
             experiment (str): Experiment description (stored in netCDF).
-            timestep (float): Iteration time step in days.
+            timestep (float or str): Iteration time step.
+                If float, time step shall be given in days.
+                If str, a timedelta string may be given
+                (see `konrad.utils.get_fraction_of_day`).
             delta (float): Stop criterion. If the heating rate is below this
                 threshold for all levels, skip further iterations.
             writeevery(int or float): Set frequency in which to write output.
@@ -88,9 +92,12 @@ class RCE:
 
         # Control parameters.
         self.delta = delta
-        self.timestep = timestep
         self.writeevery = writeevery
         self.max_iterations = max_iterations
+        if isinstance(timestep, Number):
+            self.timestep = timestep
+        elif isinstance(timestep, str):
+            self.timestep = utils.get_fraction_of_day(timestep)
 
         # TODO: Maybe delete? One could use the return value of the radiation
         # model directly.

--- a/konrad/utils.py
+++ b/konrad/utils.py
@@ -3,6 +3,7 @@
 """
 import copy
 import logging
+from datetime import timedelta
 
 import numpy as np
 import typhon as ty
@@ -20,6 +21,7 @@ __all__ = [
     'get_pressure_grids',
     'ozonesquash',
     'ozone_profile_rcemip',
+    'get_fraction_of_day',
 ]
 
 logger = logging.getLogger(__name__)
@@ -217,3 +219,34 @@ def ozone_profile_rcemip(plev, g1=3.6478, g2=0.83209, g3=11.3515):
     """
     p = plev / 100
     return g1 * p**g2 * np.exp(-p / g3) * 1e-6
+
+
+def get_fraction_of_day(timestr):
+    """Calculate the fraction of a day from a time string.
+
+    Parameters:
+        timestr (str): Specified time delta (e.g. '6h').
+            Valid units:
+                's' for seconds
+                'm' for minutes
+                'h' for hours
+                'd' for days
+                'w' for weeks
+
+    Returns:
+        float: Fraction of a day.
+
+    Example:
+        >>> get_fraction_of_day('12h')
+        0.5
+    """
+    mapping = {
+        's': 'seconds',
+        'm': 'minutes',
+        'h': 'hours',
+        'd': 'days',
+        'w': 'weeks',
+    }
+    value, period = float(timestr[:-1]), mapping[timestr[-1]]
+
+    return timedelta(**{period: value}).total_seconds() / 3600 / 24


### PR DESCRIPTION
Move the complete model control to `RCE.run()`. The `Atmosphere` class is now only used to represent the atmospheric state.