### PR TITLE
Fix non-McICA runs

### DIFF
--- a/konrad/radiation/rrtmg.py
+++ b/konrad/radiation/rrtmg.py
@@ -26,8 +26,7 @@ class RRTMG(Radiation):
         self._rad_sw = None
 
         self._mcica = mcica
-        if mcica:
-            self._cloud_ice_properties = cloud_ice_properties
+        self._cloud_ice_properties = cloud_ice_properties
 
         self.solar_constant = solar_constant
 

--- a/tutorials/radiation_solver.ipynb
+++ b/tutorials/radiation_solver.ipynb
@@ -33,7 +33,7 @@
     "cloud = konrad.cloud.ClearSky()\n",
     "\n",
     "# Setup the RRTMG radiation component (choose zenith angle and solar constant).\n",
-    "rrtmg = konrad.radiation.RRTMG(mcica=True, zenith_angle=47.88)\n",
+    "rrtmg = konrad.radiation.RRTMG(zenith_angle=47.88)\n",
     "rrtmg.calc_radiation(atmosphere, surface, cloud)  # Actual RT simulation"
    ]
   },

--- a/tutorials/simple_rce.ipynb
+++ b/tutorials/simple_rce.ipynb
@@ -10,7 +10,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x10b1b8b00>"
+       "<matplotlib.legend.Legend at 0x11e2635c0>"
       ]
      },
      "execution_count": 1,
@@ -52,7 +52,7 @@
     "# Initialize the setup for the radiative-convective equilibrium simulation.\n",
     "rce = konrad.RCE(\n",
     "    atmosphere,\n",
-    "    radiation=konrad.radiation.RRTMG(mcica=True),  # Use RRTMG radiation scheme.\n",
+    "    radiation=konrad.radiation.RRTMG(),  # Use RRTMG radiation scheme.\n",
     "    convection=konrad.convection.HardAdjustment(),  # Perform a hard convective adjustment.\n",
     "    lapserate=konrad.lapserate.MoistLapseRate(),  # Adjust towards a moist adiabat.\n",
     "    timestep='16h',  # Set timestep in model time.\n",

--- a/tutorials/venus_rce.ipynb
+++ b/tutorials/venus_rce.ipynb
@@ -76,7 +76,7 @@
     "rce = konrad.RCE(\n",
     "    atmosphere=atmosphere,\n",
     "    humidity=konrad.humidity.FixedRH(rh_surface=0, rh_tropo=0),\n",
-    "    radiation=RRTMGVenus(solar_constant=170, zenith_angle=0, mcica=True),\n",
+    "    radiation=RRTMGVenus(solar_constant=170, zenith_angle=0),\n",
     "    surface=konrad.surface.SurfaceHeatCapacity(albedo=0.7, depth=1.),\n",
     "    convection=konrad.convection.NonConvective(),\n",
     "    cloud=konrad.cloud.ClearSky(numlevels=atmosphere['plev'].size),\n",


### PR DESCRIPTION
This PR fixes runs without McICA.

I got an exception when trying to run `konrad` with `mcica=False` because `_cloud_ice_properties` was not set. I guess it is fine to set it always, for ne non-McICA cases it should simply be ignored?