### PR TITLE
Refactor component call

### DIFF
--- a/konrad/core.py
+++ b/konrad/core.py
@@ -235,7 +235,7 @@ class RCE:
                 self.convection.calculate_convective_top_height(z)
 
             # Update the ozone profile.
-            self.ozone.get(
+            self.ozone(
                 atmosphere=self.atmosphere,
                 convection=self.convection,
                 timestep=self.timestep,

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -205,7 +205,7 @@ class RCE:
             T = self.atmosphere['T'].copy()
 
             # Caculate critical lapse rate.
-            critical_lapserate = self.lapserate.get(self.atmosphere)
+            critical_lapserate = self.lapserate(self.atmosphere)
 
             # Apply heatingrates to temperature profile.
             self.atmosphere['T'] += (self.radiation['net_htngrt'] *

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -243,7 +243,7 @@ class RCE:
             )
 
             # Update the humidity profile.
-            self.atmosphere['H2O'][0, :] = self.humidity.get(
+            self.atmosphere['H2O'][0, :] = self.humidity(
                 self.atmosphere,
                 convection=self.convection,
                 surface=self.surface,

--- a/konrad/humidity.py
+++ b/konrad/humidity.py
@@ -39,7 +39,7 @@ class Humidity(Component, metaclass=abc.ABCMeta):
         self._rh_profile = rh_profile
 
     @abc.abstractmethod
-    def get(self, plev, T, z, **kwargs):
+    def __call__(self, plev, T, z, **kwargs):
         """Determine the humidity profile based on atmospheric state.
 
         Parameters:
@@ -147,7 +147,7 @@ class Humidity(Component, metaclass=abc.ABCMeta):
 
 class FixedVMR(Humidity):
     """Keep the water vapor volume mixing ratio constant."""
-    def get(self, atmosphere, **kwargs):
+    def __call__(self, atmosphere, **kwargs):
         if self._vmr_profile is None:
             self._vmr_profile = self.get_vmr_profile(atmosphere)
 
@@ -160,7 +160,7 @@ class FixedRH(Humidity):
     The relative humidity is kept constant under temperature changes,
     allowing for a moistening in a warming climate.
     """
-    def get(self, atmosphere, **kwargs):
+    def __call__(self, atmosphere, **kwargs):
         return self.get_vmr_profile(atmosphere)
 
 
@@ -181,7 +181,7 @@ class Manabe67(Humidity):
     def get_relative_humidity_profile(self, p):
         return self.rh_surface * (p / p[0] - 0.02) / (1 - 0.02)
 
-    def get(self, atmosphere, **kwargs):
+    def __call__(self, atmosphere, **kwargs):
         return self.get_vmr_profile(atmosphere)
 
 
@@ -210,7 +210,7 @@ class Cess76(FixedRH):
     def get_relative_humidity_profile(self, p):
         return self.rh_surface * ((p / p[0] - 0.02) / (1 - 0.02))**self.omega
 
-    def get(self, atmosphere, surface, **kwargs):
+    def __call__(self, atmosphere, surface, **kwargs):
         """Determine the humidity profile based on atmospheric state.
 
         Parameters:
@@ -249,7 +249,7 @@ class CoupledRH(Humidity):
                 )
                 setattr(self, attr, None)
 
-    def get(self, atmosphere, convection, **kwargs):
+    def __call__(self, atmosphere, convection, **kwargs):
         """Determine the humidity profile based on atmospheric state.
 
         Parameters:

--- a/konrad/lapserate.py
+++ b/konrad/lapserate.py
@@ -14,7 +14,7 @@ from konrad.component import Component
 class LapseRate(Component, metaclass=abc.ABCMeta):
     """Base class for all lapse rate handlers."""
     @abc.abstractmethod
-    def get(self, atmosphere):
+    def __call__(self, atmosphere):
         """Return the atmospheric lapse rate.
 
         Parameters:
@@ -24,7 +24,7 @@ class LapseRate(Component, metaclass=abc.ABCMeta):
         Returns:
               ndarray: Temperature lapse rate [K/m].
         """
-        
+
 
 class MoistLapseRate(LapseRate):
     """Moist adiabatic temperature lapse rate."""
@@ -39,7 +39,7 @@ class MoistLapseRate(LapseRate):
         self.fixed = fixed
         self._lapse_cache = None
 
-    def get(self, atmosphere):
+    def __call__(self, atmosphere):
         if self._lapse_cache is not None:
             return self._lapse_cache
 
@@ -80,7 +80,7 @@ class FixedLapseRate(LapseRate):
         """
         self.lapserate = lapserate
 
-    def get(self, atmosphere):
+    def __call__(self, atmosphere):
         if isinstance(self.lapserate, numbers.Number):
             T = atmosphere['T'][0, :]
             return self.lapserate * np.ones(T.size)

--- a/konrad/ozone.py
+++ b/konrad/ozone.py
@@ -29,7 +29,7 @@ class Ozone(Component, metaclass=abc.ABCMeta):
         self['initial_ozone'] = (('plev',), None)
 
     @abc.abstractmethod
-    def get(self, atmosphere, convection, timestep, zenith):
+    def __call__(self, atmosphere, convection, timestep, zenith):
         """Updates the ozone profile within the atmosphere class.
 
         Parameters:
@@ -45,7 +45,7 @@ class Ozone(Component, metaclass=abc.ABCMeta):
 
 class OzonePressure(Ozone):
     """Ozone fixed with pressure, no adjustment needed."""
-    def get(self, **kwargs):
+    def __call__(self, **kwargs):
         return
 
 
@@ -54,7 +54,7 @@ class OzoneHeight(Ozone):
     def __init__(self):
         self._f = None
 
-    def get(self, atmosphere, **kwargs):
+    def __call__(self, atmosphere, **kwargs):
         if self._f is None:
             self._f = interp1d(
                 atmosphere['z'][0, :],
@@ -78,7 +78,7 @@ class OzoneNormedPressure(Ozone):
         self.norm_level = norm_level
         self._f = None
 
-    def get(self, atmosphere, convection, **kwargs):
+    def __call__(self, atmosphere, convection, **kwargs):
         if self.norm_level is None:
             self.norm_level = convection.get('convective_top_plev')[0]
             # TODO: what if there is no convective top

--- a/konrad/surface.py
+++ b/konrad/surface.py
@@ -68,6 +68,7 @@ class Surface(Component, metaclass=abc.ABCMeta):
         """
         # Extrapolate surface height from geopotential height of lowest two
         # atmospheric layers.
+        atmosphere.calculate_height()
         z = atmosphere['z'][0, :]
         z_sfc = z[0] + 0.5 * (z[0] - z[1])
 


### PR DESCRIPTION
This PR:
* Changes the way some components are called.

Formerly, some components were called using their `get()`-method, e.g.:
```python
lr = konrad.lapserate.MoistLapseRate()
lr.get(atmosphere)
```
In addition to the method name being non-descriptive, it collides with the the parent class' method `Component.get()`.
The new implementation allows the user to call these components directly:
```python
lr = konrad.lapserate.MoistLapseRate()
lr(atmosphere)
```

This affects the `LapseRate`, `Ozone` and `Humidity` class.

Cheers,
Lukas