### PR TITLE
Add Zenodo metadata JSON file.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,19 @@
+{
+  "creators": [
+    {
+      "name": "Kluft, Lukas",
+      "affiliation": "Max Planck Institute for Meteorology",
+      "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "name": "Dacie, Sally",
+      "affiliation": "Max Planck Institute for Meteorology"
+    }
+  ],
+  "keywords": [
+    "python3",
+    "atmospheric-science"
+  ],
+  "language": "eng",
+  "license": "MIT License"
+}


### PR DESCRIPTION
This PR is supposed to add some metadata to Zenodo that cannot be inferred from the GitHub release alone. The approach is not really documented and hard to test as we need a release.
We could just merge this and see what happens in the next release 😉 

If you have anything to add (ORCID ID?) let me know ☺️ 