### PR TITLE
Write all components to netCDF file

### DIFF
--- a/konrad/component.py
+++ b/konrad/component.py
@@ -97,11 +97,6 @@ class Component:
         # inheriting classes using the same attributes.
         return hash((self.__class__.__name__, *hashable_values))
 
-    @property
-    def netcdf_nelem(self):
-        """Total number of netCDF elements (attributes and data variables."""
-        return len(self.data_vars) + len(self.attrs)
-
     def to_dataset(self):
         """Convert model component into an `xarray.Dataset`."""
         if self.coords is None:

--- a/konrad/humidity/__init__.py
+++ b/konrad/humidity/__init__.py
@@ -95,5 +95,10 @@ class FixedRH(Component):
 
 class FixedVMR(Component):
     """Keep the water vapor volume mixing ratio constant."""
+    def __init__(self):
+        # Set both attributes for consistent user interface and netCDF output.
+        self._rh_func = None
+        self._stratosphere_coupling = None
+
     def adjust_humidity(self, atmosphere, **kwargs):
         return

--- a/konrad/netcdf.py
+++ b/konrad/netcdf.py
@@ -137,8 +137,7 @@ class NetcdfHandler:
         if len(self._component_cache) == 0:
             for attr in dir(self.rce):
                 if ((not attr.startswith('_')
-                     and isinstance(getattr(self.rce, attr), Component)
-                     and getattr(self.rce, attr).netcdf_nelem > 0)):
+                     and isinstance(getattr(self.rce, attr), Component))):
                     self._component_cache.append(attr)
 
         # Ensure that the atmosphere component is stored first as it holds


### PR DESCRIPTION
Model components are now stored in the netCDF output regardless of their
number of attributes and variables. This ensures that at least their
classname is saved for documentation.