### PR TITLE
Calculate moist heat capacity and heating rates

### DIFF
--- a/docs/source/konrad.radiation.rst
+++ b/docs/source/konrad.radiation.rst
@@ -8,3 +8,4 @@ Radiation
 
    Radiation
    RRTMG
+   fluxes2heating

--- a/konrad/atmosphere.py
+++ b/konrad/atmosphere.py
@@ -424,6 +424,21 @@ class Atmosphere(Component):
 
         return max_plev
 
+    def get_heat_capacity(self):
+        r"""Calculate specific heat capacity at constant pressure of moist air
+
+        .. math::
+            c_p = X \cdot (c_{p,v} - c_{p,d}) + c_{p,d}
+
+        Returns:
+            ndarray: Heat capacity [J/K/kg].
+        """
+        cpd = constants.isobaric_mass_heat_capacity_dry_air
+        cpv = constants.isobaric_mass_heat_capacity_water_vapor
+        x = self['H2O'][-1]
+
+        return x * (cpv - cpd) + cpd
+
     def tracegases_rcemip(self):
         """Set trace gas concentrations according to the RCE-MIP configuration.
 

--- a/konrad/constants.py
+++ b/konrad/constants.py
@@ -5,8 +5,9 @@ import scipy.constants as spc
 import typhon.constants as tyc
 
 
-# Phyiscal constants
-Cp = isobaric_mass_heat_capacity = 1003.5  # J kg^-1 K^-1
+# Physical constants
+c_pd = isobaric_mass_heat_capacity_dry_air = 1004.64  # J kg^-1 K^-1
+c_pv = isobaric_mass_heat_capacity_water_vapor = 1860.46  # J kg^-1 K^-1
 g = earth_standard_gravity = spc.g  # m s^-2
 stefan_boltzmann = 5.67e-8  # W m^-2 K^-4
 heat_of_vaporization = Lv = 2501000  # J kg^-1

--- a/konrad/constants.py
+++ b/konrad/constants.py
@@ -19,6 +19,7 @@ specific_heat_capacity_sea_water = 4185.5  # J kg^-1 K^-1
 molar_gas_constant_dry_air = molar_Rd = spc.gas_constant  # J mol^-1 K^-1
 avogadro = tyc.avogadro  # molecules per mole
 triple_point_water = 273.16  # K
+seconds_in_a_day = 24 * 60 * 60  # s
 
 # Variable descriptions
 variable_description = {

--- a/konrad/convection.py
+++ b/konrad/convection.py
@@ -41,7 +41,7 @@ __all__ = [
 ]
 
 
-def energy_difference_dry(T_2, T_1, sst_2, sst_1, phlev, eff_Cp_s):
+def energy_difference_dry(T_2, T_1, sst_2, sst_1, phlev, Cp, eff_Cp_s):
     """
     Calculate the energy difference between two atmospheric profiles (2 - 1).
 
@@ -52,9 +52,9 @@ def energy_difference_dry(T_2, T_1, sst_2, sst_1, phlev, eff_Cp_s):
         sst_1: surface temperature (1)
         phlev: pressure half-levels [Pa]
             must be the same for both atmospheric profiles
+        Cp: Specific isobaric heat capacity of the atmosphere.
         eff_Cp_s: effective heat capacity of surface
     """
-    Cp = constants.isobaric_mass_heat_capacity
     g = constants.g
 
     dT = T_2 - T_1  # convective temperature change of atmosphere
@@ -402,7 +402,8 @@ class HardAdjustment(Convection):
         # difference in energy due to temperature change between radiatively
         # and convectively adjusted profiles
         diff = energy_difference_dry(
-            T_con, T_rad, surfaceT, surface['temperature'], phlev, eff_Cp_s)
+            T_con, T_rad, surfaceT, surface['temperature'], phlev,
+            atmosphere.get_heat_capacity(), eff_Cp_s)
 
         # difference due to latent heating between previous timestep and
         # current timestep

--- a/konrad/lapserate.py
+++ b/konrad/lapserate.py
@@ -69,7 +69,7 @@ class MoistLapseRate(LapseRate):
         L = constants.heat_of_vaporization
         Rd = constants.specific_gas_constant_dry_air
         Rv = constants.specific_gas_constant_water_vapor
-        Cp = constants.isobaric_mass_heat_capacity
+        Cp = constants.isobaric_mass_heat_capacity_dry_air
 
         gamma_d = g / Cp  # dry lapse rate
 

--- a/konrad/radiation/__init__.py
+++ b/konrad/radiation/__init__.py
@@ -22,6 +22,7 @@ cloudy and clear-sky, longwave and shortwave radiative fluxes and heating rates.
 """
 from .radiation import Radiation
 from .rrtmg import RRTMG
+from .common import *
 
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/konrad/radiation/common.py
+++ b/konrad/radiation/common.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from konrad import constants
+
+
+def fluxes2heating(net_fluxes, pressure, cp=None, method='diff'):
+    r"""Calculate radiative heating from net fluxes
+
+    .. math::
+        Q_\mathrm{r} = \frac{F}{c_p} \frac{\mathrm{d}F}{\mathrm{d}p}
+
+    Parameters:
+        net_fluxes (ndarray): Net radiative flux.
+        pressure (ndarray): Pressure level.
+        cp (float or ndarray): Specific heat capacity. If ``None`` use
+            specific heat capacity of dry air.
+        method (str): Method used to derive the radiative fluxes
+            ("diff" or "gradient").
+
+    Returns:
+        ndarray: Radiative heating [K/day].
+    """
+    g = constants.earth_standard_gravity
+    if cp is None:
+        cp = constants.isobaric_mass_heat_capacity_dry_air
+
+    if method == 'diff':
+        dfdp = np.diff(net_fluxes) / np.diff(pressure)
+    elif method == 'gradient':
+        dfdp = np.gradient(net_fluxes, pressure)
+    else:
+        raise ValueError(f'Method has to be "diff" or "gradient".')
+
+    heating = g / cp * dfdp
+
+    return heating * constants.seconds_in_a_day  # K/s -> K/day

--- a/konrad/radiation/radiation.py
+++ b/konrad/radiation/radiation.py
@@ -8,7 +8,7 @@ from scipy.interpolate import interp1d
 
 from konrad import constants
 from konrad.component import Component
-from konrad.utils import append_description
+from konrad.radiation.common import fluxes2heating
 
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,30 @@ class Radiation(Component, metaclass=abc.ABCMeta):
         self.calc_radiation(atmosphere, surface, cloud)
 
         # self.correct_bias(rad_dataset)
+
+        self['sw_htngrt'][-1] = fluxes2heating(
+            net_fluxes=self['sw_flxu'][-1] - self['sw_flxd'][-1],
+            pressure=atmosphere['phlev'],
+            cp=atmosphere.get_heat_capacity(),
+        )
+
+        self['sw_htngrt_clr'][-1] = fluxes2heating(
+            net_fluxes=self['sw_flxu_clr'][-1] - self['sw_flxd_clr'][-1],
+            pressure=atmosphere['phlev'],
+            cp=atmosphere.get_heat_capacity(),
+        )
+
+        self['lw_htngrt'][-1] = fluxes2heating(
+            net_fluxes=self['lw_flxu'][-1] - self['lw_flxd'][-1],
+            pressure=atmosphere['phlev'],
+            cp=atmosphere.get_heat_capacity(),
+        )
+
+        self['lw_htngrt_clr'][-1] = fluxes2heating(
+            net_fluxes=self['lw_flxu_clr'][-1] - self['lw_flxd_clr'][-1],
+            pressure=atmosphere['phlev'],
+            cp=atmosphere.get_heat_capacity(),
+        )
 
         self.derive_diagnostics()
 

--- a/konrad/upwelling.py
+++ b/konrad/upwelling.py
@@ -75,7 +75,7 @@ class StratosphericUpwelling(Upwelling):
         dTdz = np.gradient(atmosphere['T'][0, :], atmosphere['z'][0, :])
 
         g = constants.g
-        Cp = constants.Cp
+        Cp = atmosphere.get_heat_capacity()
         Q = -self.w * (dTdz + g/Cp)
 
         return Q


### PR DESCRIPTION
This PR:
* Add a method to calculate the water-vapor-dependent specific isobaric heat capacity of the atmosphere
* Calculate the radiative heating tendency from from the radiative fluxes returned by RRTMG. This removes a bias in the equilibrium state, which was presumably introduced by a mismatch in the treatment of vertical coordinates