### PR TITLE
Undo things - do not include latent heat in convective adjustment

### DIFF
--- a/docs/source/konrad.convection.rst
+++ b/docs/source/konrad.convection.rst
@@ -6,12 +6,9 @@ Convection Scheme
 .. autosummary::
    :toctree: _autosummary
 
-   energy_difference_dry
-   latent_heat_difference
+   energy_difference
    interp_variable
    pressure_lapse_rate
-   update_temporary_atmosphere
-   water_vapour_profile
    Convection
    NonConvective
    HardAdjustment

--- a/konrad/convection.py
+++ b/konrad/convection.py
@@ -19,7 +19,6 @@ import abc
 
 import numpy as np
 import typhon
-from typhon.physics import vmr2mixing_ratio
 from scipy.interpolate import interp1d
 
 from konrad import constants
@@ -28,8 +27,7 @@ from konrad.surface import SurfaceFixedTemperature
 
 
 __all__ = [
-    'energy_difference_dry',
-    'latent_heat_difference',
+    'energy_difference',
     'interp_variable',
     'pressure_lapse_rate',
     'Convection',
@@ -39,7 +37,7 @@ __all__ = [
 ]
 
 
-def energy_difference_dry(T_2, T_1, sst_2, sst_1, phlev, Cp, eff_Cp_s):
+def energy_difference(T_2, T_1, sst_2, sst_1, phlev, eff_Cp_s):
     """
     Calculate the energy difference between two atmospheric profiles (2 - 1).
 
@@ -50,9 +48,9 @@ def energy_difference_dry(T_2, T_1, sst_2, sst_1, phlev, Cp, eff_Cp_s):
         sst_1: surface temperature (1)
         phlev: pressure half-levels [Pa]
             must be the same for both atmospheric profiles
-        Cp: Specific isobaric heat capacity of the atmosphere.
         eff_Cp_s: effective heat capacity of surface
     """
+    Cp = constants.c_pd
     g = constants.g
 
     dT = T_2 - T_1  # convective temperature change of atmosphere
@@ -133,59 +131,17 @@ def pressure_lapse_rate(p, phlev, T, lapse):
     return lp
 
 
-def update_temporary_atmosphere(atmosphere, T, humidity):
-    """
-    Update atmospheric temperature, corresponding water vapour content,
-    and height.
-
-    Parameters:
-        atmosphere (konrad.atmosphere): atmosphere model to be updated
-        T (ndarray): temperature profile
-        humidity (konrad.humidity): humidity model
-    """
-    atmosphere['T'][-1] = T
-    humidity.adjust_humidity(
-        atmosphere=atmosphere,
-    )
-    atmosphere.update_height()
-    return
-
-
-def water_vapour_profile(atmosphere):
-    """Calculate the mass of water vapour in each model layer
-
-    Parameters:
-        atmosphere (konrad.atmosphere): atmosphere model
-    Returns:
-        ndarray: atmospheric water vapour content [kg m^-2]
-    """
-
-    h2o = vmr2mixing_ratio(atmosphere['H2O'][-1])
-
-    rho = typhon.physics.density(
-        atmosphere['plev'], atmosphere['T'][-1])  # kg m-3
-    z = atmosphere.get('z')[-1]  # m
-    dz = np.gradient(z)  # TODO: gradient or calculate diff from half levels?
-    h2o *= rho * dz  # kg m-2
-
-    return h2o
-
-
 class Convection(Component, metaclass=abc.ABCMeta):
     """Base class to define abstract methods for convection schemes."""
     @abc.abstractmethod
-    def stabilize(self, atmosphere, atmosphere_old, humidity, lapse, surface,
-                  timestep):
+    def stabilize(self, atmosphere, lapse, surface, timestep):
         """Stabilize the temperature profile by redistributing energy.
 
         Parameters:
-            atmosphere (konrad.atmosphere): atmosphere model
-            atmosphere_old (konrad.atmosphere): atmosphere model with properties
-                of previous timestep
-            humidity (konrad.humidity): humidity model
-            lapse (ndarray): Temperature lapse rate [K/day].
-            surface (konrad.surface): Surface model.
-            timestep (float): Timestep width [day].
+              atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
+              lapse (ndarray): Temperature lapse rate [K/day].
+              surface (konrad.surface): Surface model.
+              timestep (float): Timestep width [day].
         """
 
 
@@ -197,16 +153,13 @@ class NonConvective(Convection):
 
 class HardAdjustment(Convection):
     """Instantaneous adjustment of temperature profiles"""
-    def stabilize(self, atmosphere, atmosphere_old, humidity, lapse, surface, timestep):
+    def stabilize(self, atmosphere, lapse, surface, timestep):
 
         T_rad = atmosphere['T'][0, :]
         p = atmosphere['plev']
 
         # Find convectively adjusted temperature profile.
         T_new, T_s_new = self.convective_adjustment(
-            atmosphere,
-            atmosphere_old,
-            humidity,
             p=p,
             phlev=atmosphere['phlev'],
             T_rad=T_rad,
@@ -220,8 +173,8 @@ class HardAdjustment(Convection):
         atmosphere['T'][0, :] = T_new
         surface['temperature'][0] = T_s_new
 
-    def convective_adjustment(self, atmosphere, atmosphere_old, humidity, p,
-                              phlev, T_rad, lapse, surface, timestep=0.1):
+    def convective_adjustment(self, p, phlev, T_rad, lapse, surface,
+                              timestep=0.1):
         """
         Find the energy-conserving temperature profile using upper and lower
         bound profiles (calculated from surface temperature extremes: no change
@@ -264,7 +217,6 @@ class HardAdjustment(Convection):
         # associated with an increase in energy in the atmosphere.
         surfaceTpos = surface['temperature']
         T_con, diff_pos = self.create_and_check_profile(
-            atmosphere, atmosphere_old, humidity,
             T_rad, p, phlev, surface, surfaceTpos, lp, timestep=timestep)
 
         # For other cases, if we find a decrease or approx no change in energy,
@@ -300,7 +252,6 @@ class HardAdjustment(Convection):
             # Calculate temperature profile and energy change associated with
             # this surface temperature.
             T_con, diff = self.create_and_check_profile(
-                atmosphere, atmosphere_old, humidity,
                 T_rad, p, phlev, surface, surfaceT, lp, timestep=timestep)
 
             # Update either upper or lower bound.
@@ -353,11 +304,9 @@ class HardAdjustment(Convection):
 
         return T_con
 
-    def create_and_check_profile(self, atmosphere, atmosphere_old, humidity,
-                                 T_rad, p, phlev,
-                                 surface, surfaceT, lp, timestep=0.1):
-        """
-        Create a convectively adjusted temperature profile and calculate how
+    def create_and_check_profile(self, T_rad, p, phlev, surface, surfaceT, lp,
+                                 timestep=0.1):
+        """Create a convectively adjusted temperature profile and calculate how
         close it is to satisfying energy conservation.
 
         Parameters:
@@ -379,24 +328,8 @@ class HardAdjustment(Convection):
 
         eff_Cp_s = surface.heat_capacity
 
-        atmosphere_con = atmosphere.copy()
-        update_temporary_atmosphere(atmosphere_con, T_con, humidity)
-
-        h2o_old = water_vapour_profile(atmosphere_old)
-        h2o_new = water_vapour_profile(atmosphere_con)
-
-        # difference in energy due to temperature change between radiatively
-        # and convectively adjusted profiles
-        diff = energy_difference_dry(
-            T_con, T_rad, surfaceT, surface['temperature'], phlev,
-            atmosphere.get_heat_capacity(), eff_Cp_s)
-
-        # difference due to latent heating between previous timestep and
-        # current timestep
-        wet_diff = latent_heat_difference(h2o_new, h2o_old)
-
-        diff += wet_diff
-
+        diff = energy_difference(T_con, T_rad, surfaceT,
+                                 surface['temperature'], phlev, eff_Cp_s)
         return T_con, float(diff)
 
     def update_convective_top(self, T_rad, T_con, p, timestep=0.1, lim=0.2):

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -263,6 +263,8 @@ class RCE:
             # Update the humidity profile.
             self.humidity.adjust_humidity(
                 atmosphere=self.atmosphere,
+                convection=self.convection,
+                surface=self.surface,
             )
 
             self.cloud.update_cloud_profile(self.atmosphere,

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -220,7 +220,6 @@ class RCE:
 
             # Save the old temperature profile. They are compared with
             # adjusted values to check if the model has converged.
-            atmosphere_old = self.atmosphere.copy()
             T = self.atmosphere['T'].copy()
 
             # Caculate critical lapse rate.
@@ -233,8 +232,6 @@ class RCE:
             # Convective adjustment
             self.convection.stabilize(
                 atmosphere=self.atmosphere,
-                atmosphere_old=atmosphere_old,
-                humidity=self.humidity,
                 lapse=critical_lapserate,
                 timestep=self.timestep,
                 surface=self.surface,


### PR DESCRIPTION
This PR satisfies #80 and undoes most of PR #68, so the convective adjustment should work as before now (ie not taking into account latent heat in the energy balance). The only thing I left was the function to copy the atmosphere, because this may be useful for other things too. If at some point we decide we do want to include humidity changes in the energy considerations for the convective adjustment or just make another check that they are not important, we can always revert these reverted commits again :)