### PR TITLE
Revise functions

### DIFF
--- a/docs/source/konrad.utils.rst
+++ b/docs/source/konrad.utils.rst
@@ -9,7 +9,7 @@ Utilities
    append_description
    append_timestep_netcdf
    return_if_type
-   phlev_from_plev
+   plev_from_phlev
    dz_from_z
    refined_pgrid
    get_pressure_grids

--- a/docs/source/konrad.utils.rst
+++ b/docs/source/konrad.utils.rst
@@ -11,7 +11,8 @@ Utilities
    return_if_type
    plev_from_phlev
    dz_from_z
-   refined_pgrid
+   get_squeezable_pgrid
+   get_quadratic_pgrid
    get_pressure_grids
    ozonesquash
    ozone_profile_rcemip

--- a/konrad/atmosphere.py
+++ b/konrad/atmosphere.py
@@ -44,19 +44,20 @@ class Atmosphere(Component):
     ]
     pmin = 10e2
 
-    def __init__(self, plev):
+    def __init__(self, phlev):
         """Initialise atmosphere component.
 
         Parameters:
-            plev (``np.ndarray``): Atmospheric pressure (surface to top) [Pa].
+            phlev (``np.ndarray``): Atmospheric pressure at half-levels
+              (surface to top) [Pa].
         """
         super().__init__()
+        plev = utils.plev_from_phlev(phlev)
 
         self.coords = {
             'time': np.array([]),  # time dimension
             'plev': plev,  # pressure at full-levels
-            # TODO: Should `phlev` be input?
-            'phlev': utils.phlev_from_plev(plev)  # pressure at halflevels
+            'phlev': phlev,  # pressure at half-levels
         }
 
         for varname in self.atmosphere_variables:
@@ -127,8 +128,7 @@ class Atmosphere(Component):
         #  Consider a more flexible user interface.
 
         # Create a Dataset with time and pressure dimension.
-        plev = dictionary['plev']
-        d = cls(plev=plev)
+        d = cls(phlev=dictionary['phlev'])
 
         for var in cls.atmosphere_variables:
             val = dictionary.get(var)
@@ -165,7 +165,7 @@ class Atmosphere(Component):
                         for var in cls.atmosphere_variables
                         if var in dataset.variables
                         }
-            datadict['plev'] = np.array(root['plev'][:])
+            datadict['phlev'] = np.array(root['phlev'][:])
 
         return cls.from_dict(datadict)
 

--- a/konrad/humidity/relative_humidity.py
+++ b/konrad/humidity/relative_humidity.py
@@ -2,7 +2,6 @@
 import abc
 
 import numpy as np
-from scipy.stats import norm
 from scipy.interpolate import interp1d
 
 from konrad.component import Component
@@ -123,12 +122,9 @@ class FixedUTH(RelativeHumidityModel):
             manabe_model = Manabe67(rh_surface=self.rh_surface)
             self._rh_base_profile = manabe_model(atmosphere)
 
-        # Add skew-normal distribution.
-        uth = self.uth * norm.pdf(
-            x=np.log(p),
-            loc=np.log(self.uth_plev + self.uth_offset),
-            scale=0.4,
-        )
+        # Gaussian upper-tropospheric UTH peak in ln(p) coordinates
+        x = p / (self.uth_plev + self.uth_offset)
+        uth = self.uth * np.exp(-np.log(x)**2 * np.pi)
 
         return np.maximum(self._rh_base_profile, uth)
 

--- a/konrad/test/test_atmosphere.py
+++ b/konrad/test/test_atmosphere.py
@@ -8,9 +8,9 @@ from konrad import (atmosphere, utils)
 
 @pytest.fixture
 def atmosphere_obj():
-    plev, _ = utils.get_pressure_grids(surface_pressure=1000e2, num=50)
+    _, phlev = utils.get_pressure_grids(surface_pressure=1000e2, num=50)
 
-    return atmosphere.Atmosphere(plev=plev)
+    return atmosphere.Atmosphere(phlev=phlev)
 
 
 class TestAtmosphere:
@@ -18,9 +18,9 @@ class TestAtmosphere:
 
     def test_init(self):
         """Test basic initialization of the atmosphere component."""
-        plev = np.array([1000e2, 750e2, 500e2, 100e2, 10e2, 1e2])
+        phlev = np.array([1000e2, 750e2, 500e2, 100e2, 10e2, 1e2])
 
-        atmosphere.Atmosphere(plev=plev)
+        atmosphere.Atmosphere(phlev=phlev)
 
     def test_cold_point_index(self, atmosphere_obj):
         """Test retrieval of the cold point index."""

--- a/konrad/test/test_atmosphere.py
+++ b/konrad/test/test_atmosphere.py
@@ -8,7 +8,7 @@ from konrad import (atmosphere, utils)
 
 @pytest.fixture
 def atmosphere_obj():
-    plev, _ = utils.get_pressure_grids(1000e2, 1, 50)
+    plev, _ = utils.get_pressure_grids(surface_pressure=1000e2, num=50)
 
     return atmosphere.Atmosphere(plev=plev)
 
@@ -32,11 +32,11 @@ class TestAtmosphere:
 
     def test_cold_point_plev(self, atmosphere_obj):
         """Test retrieval of the cold point pressure."""
-        assert np.isclose(atmosphere_obj.get_cold_point_plev(), 20023.067)
+        assert np.isclose(atmosphere_obj.get_cold_point_plev(), 19611.012)
 
     def test_triple_point_plev(self, atmosphere_obj):
         """Test retrieval of the triple point plev."""
-        assert np.isclose(atmosphere_obj.get_triple_point_plev(), 74287.948)
+        assert np.isclose(atmosphere_obj.get_triple_point_plev(), 73875.426)
 
     def test_from_netcdf(self):
         """Test initialisation from netCDF file."""

--- a/konrad/utils.py
+++ b/konrad/utils.py
@@ -16,7 +16,7 @@ __all__ = [
     'append_description',
     'append_timestep_netcdf',
     'return_if_type',
-    'phlev_from_plev',
+    'plev_from_phlev',
     'dz_from_z',
     'refined_pgrid',
     'get_pressure_grids',
@@ -115,23 +115,21 @@ def return_if_type(variable, variablename, expect, default):
     return variable
 
 
-def phlev_from_plev(fulllevels):
-    """Returns the linear interpolated halflevels for given array.
+def plev_from_phlev(halflevels):
+    """Returns full-level pressures for given half-level pressures.
+
+    The interpolation is performed in log-space.
 
     Parameters:
-        fulllevels (ndarray): Pressure at fullevels.
+        halflevels (ndarray): Pressure at full-levels.
 
     Returns:
-        ndarray: Coordinates at halflevel.
+        ndarray: Pressure at full-level.
 
     """
-    plev_log = np.log(fulllevels)  # Perform inter-/extrapolation in log-space
+    phlev_log = np.log(halflevels)
 
-    inter = 0.5 * (plev_log[1:] + plev_log[:-1])
-    bottom = plev_log[0] + 0.5 * (plev_log[0] - plev_log[1])
-    top = plev_log[-1] - 0.5 * (plev_log[-2] - plev_log[-1])
-
-    return np.exp(np.hstack((bottom, inter, top)))
+    return np.exp(0.5 * (phlev_log[1:] + phlev_log[:-1]))
 
 
 def dz_from_z(z):
@@ -197,7 +195,7 @@ def get_pressure_grids(surface_pressure=1000e2, num=200):
     i = np.linspace(0, 1, num + 1)
     lnps = np.log(surface_pressure)
     phlev = np.exp(-lnps/2 * (i**2 + i) + lnps)
-    plev = np.exp(0.5 * (np.log(phlev[1:]) + np.log(phlev[:-1])))
+    plev = plev_from_phlev(phlev)
 
     return plev, phlev
 

--- a/konrad/utils.py
+++ b/konrad/utils.py
@@ -176,23 +176,27 @@ def refined_pgrid(start, stop, num=200, shift=0.5, fixpoint=0.):
     return grid
 
 
-def get_pressure_grids(start=1000e2, stop=1, num=200, squeeze=0.5):
-    """Create matching pressure levels and half-levels.
+def get_pressure_grids(surface_pressure=1000e2, num=200):
+    r"""Create matching pressure levels and half-levels.
+
+    The half-levels range from ``surface_pressure`` to 1 Pa.
+
+    The pressure for every level ``i`` ([0, 1]) is given by:
+
+    .. math::
+         \ln(p) = -\frac{\ln(p_\mathrm{s})}{2}
+                  \left(i^2 + i\right) + \ln(p_\mathrm{s})
 
     Parameters:
-        start (float): Pressure of the lowest half-level (surface) [Pa].
-        stop (float): Pressure of the highest half-level (TOA) [Pa].
+        surface_pressure (float): Pressure of the lowest half-level [Pa].
         num (int): Number of **full** pressure levels.
-        squeeze (float): Factor with which the first step width is
-            squeezed in logspace. Has to be between ``(0, 2)``.
-            Values smaller than one compress the half-levels,
-            while values greater than 1 stretch the spacing.
-            The default is ``0.5`` (bottom heavy.)
 
     Returns:
         ndarray, ndarray: Full-level pressure, half-level pressure [Pa].
     """
-    phlev = ty.math.squeezable_logspace(start, stop, num + 1, squeeze=squeeze)
+    i = np.linspace(0, 1, num + 1)
+    lnps = np.log(surface_pressure)
+    phlev = np.exp(-lnps/2 * (i**2 + i) + lnps)
     plev = np.exp(0.5 * (np.log(phlev[1:]) + np.log(phlev[:-1])))
 
     return plev, phlev

--- a/konrad/utils.py
+++ b/konrad/utils.py
@@ -18,7 +18,8 @@ __all__ = [
     'return_if_type',
     'plev_from_phlev',
     'dz_from_z',
-    'refined_pgrid',
+    'get_squeezable_pgrid',
+    'get_quadratic_pgrid',
     'get_pressure_grids',
     'ozonesquash',
     'ozone_profile_rcemip',
@@ -146,7 +147,8 @@ def dz_from_z(z):
     return dz
 
 
-def refined_pgrid(start, stop, num=200, shift=0.5, fixpoint=0.):
+def get_squeezable_pgrid(start=1000e2, stop=1, num=200, shift=0.5,
+                                 fixpoint=0.):
     """Create a pressure grid with adjustable distribution in logspace.
 
     Notes:
@@ -155,9 +157,9 @@ def refined_pgrid(start, stop, num=200, shift=0.5, fixpoint=0.):
     Parameters:
         start (float): The starting value of the sequence.
         stop (float): The end value of the sequence.
-        num (int): Number of sample to generate (Default is 50).
+        num (int): Number of sample to generate.
         shift (float): Factor with which the first stepwidth is
-            squeezed in logspace. Has to be between  ``(0, 2)`.
+            squeezed in logspace. Has to be between  ``(0, 2)``.
             Values smaller than one compress the gridpoints,
             while values greater than 1 strecht the spacing.
             The default is ``0.5`` (bottom heavy.)
@@ -174,7 +176,7 @@ def refined_pgrid(start, stop, num=200, shift=0.5, fixpoint=0.):
     return grid
 
 
-def get_pressure_grids(surface_pressure=1000e2, num=200):
+def get_quadratic_pgrid(surface_pressure=1000e2, num=200):
     r"""Create matching pressure levels and half-levels.
 
     The half-levels range from ``surface_pressure`` to 1 Pa.
@@ -192,9 +194,28 @@ def get_pressure_grids(surface_pressure=1000e2, num=200):
     Returns:
         ndarray, ndarray: Full-level pressure, half-level pressure [Pa].
     """
-    i = np.linspace(0, 1, num + 1)
+    i = np.linspace(0, 1, num)
     lnps = np.log(surface_pressure)
-    phlev = np.exp(-lnps/2 * (i**2 + i) + lnps)
+
+    return np.exp(-lnps/2 * (i**2 + i) + lnps)
+
+
+def get_pressure_grids(surface_pressure=1000e2, num=200):
+    r"""Create matching pressures at full-levels and half-levels.
+
+    The half-levels range from ``surface_pressure`` to 1 Pa.
+
+    Parameters:
+        surface_pressure (float): Pressure of the lowest half-level [Pa].
+        num (int): Number of **full** pressure levels.
+
+    Returns:
+        ndarray, ndarray: Full-level pressure, half-level pressure [Pa].
+
+    See also:
+        ``konrad.utils.get_quadratic_pgrid``
+    """
+    phlev = get_quadratic_pgrid(surface_pressure=surface_pressure, num=num+1)
     plev = plev_from_phlev(phlev)
 
     return plev, phlev


### PR DESCRIPTION
This PR
* fixes the scaling of the upper-tropospheric UTH peak (``FixedUTH``, ``CoupledUTH``)
* simplifies the generation of pressure grids by using an analytical formula and less free parameters

The changes lead to the following API changes:
The function ``get_pressure_grids`` no longer supports the ``stop`` and ``squeeze`` arguments. The top-level pressure is now fixed to 1 Pa and a constant "default squeezing" is applied.