### PR TITLE
Fix attribute getter for model components

### DIFF
--- a/konrad/component.py
+++ b/konrad/component.py
@@ -46,7 +46,10 @@ class Component:
             self._attrs[name] = value
 
     def __getattr__(self, name):
-        return self._attrs[name]
+        try:
+            return self._attrs[name]
+        except KeyError as exc:
+            raise AttributeError(exc)
 
     @property
     def attrs(self):


### PR DESCRIPTION
The method ``__getattr__``now raises a proper ``AttributeError``
when an attribute cannot be found. This fixes the pickle-ability of
component objects (needed for multiprocessing).