### PR TITLE
Use dry heat capacity to calculate heating rates

### DIFF
--- a/konrad/radiation/radiation.py
+++ b/konrad/radiation/radiation.py
@@ -84,25 +84,21 @@ class Radiation(Component, metaclass=abc.ABCMeta):
         self['sw_htngrt'][-1] = fluxes2heating(
             net_fluxes=self['sw_flxu'][-1] - self['sw_flxd'][-1],
             pressure=atmosphere['phlev'],
-            cp=atmosphere.get_heat_capacity(),
         )
 
         self['sw_htngrt_clr'][-1] = fluxes2heating(
             net_fluxes=self['sw_flxu_clr'][-1] - self['sw_flxd_clr'][-1],
             pressure=atmosphere['phlev'],
-            cp=atmosphere.get_heat_capacity(),
         )
 
         self['lw_htngrt'][-1] = fluxes2heating(
             net_fluxes=self['lw_flxu'][-1] - self['lw_flxd'][-1],
             pressure=atmosphere['phlev'],
-            cp=atmosphere.get_heat_capacity(),
         )
 
         self['lw_htngrt_clr'][-1] = fluxes2heating(
             net_fluxes=self['lw_flxu_clr'][-1] - self['lw_flxd_clr'][-1],
             pressure=atmosphere['phlev'],
-            cp=atmosphere.get_heat_capacity(),
         )
 
         self.derive_diagnostics()


### PR DESCRIPTION
The heat capacity for dry air is used to convert radiative fluxes into
heating rates. This is consistent with the approach done in the
convective adjustment: The choice of the heat capacity does not affect
the equilibrium state as long as it is consistent for radiation and
convection.