### PR TITLE
Revise humidity models

### DIFF
--- a/konrad/humidity/__init__.py
+++ b/konrad/humidity/__init__.py
@@ -27,7 +27,11 @@ class FixedRH(Component):
         else:
             self._stratosphere_coupling = stratosphere_coupling
 
-        self._rh_func = rh_func
+        if rh_func is None:
+            self._rh_func = CacheFromAtmosphere()
+        else:
+            self._rh_func = rh_func
+
         self._rh_profile = None
 
     @property
@@ -74,19 +78,8 @@ class FixedRH(Component):
         Returns:
             ndarray: Water vapor profile [VMR].
         """
-        if self._rh_func is not None:
-           rh_profile = self._rh_func(atmosphere, **kwargs)
-        else:
-            if self._rh_profile is None:
-                self._rh_profile = vmr2relative_humidity(
-                        vmr=atmosphere['H2O'][-1],
-                        pressure=atmosphere['plev'],
-                        temperature=atmosphere['T'][-1]
-                    )
-            rh_profile = self._rh_profile
-
         atmosphere['H2O'][-1, :] = relative_humidity2vmr(
-            relative_humidity=rh_profile,
+            relative_humidity=self._rh_func(atmosphere, **kwargs),
             pressure=atmosphere['plev'],
             temperature=atmosphere['T'][-1]
 

--- a/konrad/humidity/relative_humidity.py
+++ b/konrad/humidity/relative_humidity.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 from konrad.component import Component
+from konrad.physics import vmr2relative_humidity
 
 
 class RelativeHumidityModel(Component, metaclass=abc.ABCMeta):
@@ -20,6 +21,21 @@ class RelativeHumidityModel(Component, metaclass=abc.ABCMeta):
             ndarray: Relative humidity profile.
         """
         ...
+
+
+class CacheFromAtmosphere(RelativeHumidityModel):
+    """Calculate and cache relative humidity from initial atmosphere."""
+    def __init__(self):
+        self._rh_profile = None
+
+    def __call__(self, atmosphere, **kwargs):
+        if self._rh_profile is None:
+            self._rh_profile = vmr2relative_humidity(
+                vmr=atmosphere['H2O'][-1],
+                pressure=atmosphere['plev'],
+                temperature=atmosphere['T'][-1]
+            )
+        return self._rh_profile
 
 
 class HeightConstant(RelativeHumidityModel):

--- a/konrad/humidity/stratosphere.py
+++ b/konrad/humidity/stratosphere.py
@@ -74,18 +74,3 @@ class MinimumStratosphericVMR(StratosphereCoupler):
             # from there on, this at least minimizes the discontinuity at
             # the transition point.
             vmr[np.argmin(vmr):] = self.minimum_vmr
-
-
-class NoCoupling(StratosphereCoupler):
-    """Do not adjust stratospheric water vapor.
-
-    This coupler does not change the stratospheric water vapor at all. It
-    may be used together with ``konrad.humidityy.FixedVMR()`` to perform
-    simulations for a given set of VMR values (e.g. observations).
-
-    Warning:
-        This may lead to unrealistic atmospheric states when using models to
-        describe the vertical relative humidity distribution!
-    """
-    def adjust_stratospheric_vmr(self, atmosphere):
-        return


### PR DESCRIPTION
This PR:
* Adds the class `CacheFromAtmosphere` to calculate and store the initial relative humidity profile
* Removes the `NoCoupling` stratospheric coupling as it did not work as expected