### PR TITLE
Adjust co2

### DIFF
--- a/konrad/constants.py
+++ b/konrad/constants.py
@@ -85,7 +85,7 @@ variable_description = {
         'units': '1',
         'standard_name': 'carbon_dioxide_mixing_ratio',
         'arts_name': 'abs_species-CO2',
-        'dims': ('plev',),
+        'dims': ('time', 'plev',),
         'default_vmr': 348e-6,
         },
     'CO': {

--- a/konrad/convection.py
+++ b/konrad/convection.py
@@ -23,7 +23,7 @@ from scipy.interpolate import interp1d
 
 from konrad import constants
 from konrad.component import Component
-from konrad.surface import SurfaceFixedTemperature
+from konrad.surface import FixedTemperature
 
 
 __all__ = [
@@ -201,7 +201,7 @@ class HardAdjustment(Convection):
 
         # This is the temperature profile required if we have a set-up with a
         # fixed surface temperature. In this case, energy is not conserved.
-        if isinstance(surface, SurfaceFixedTemperature):
+        if isinstance(surface, FixedTemperature):
             T_con = self.convective_profile(
                 T_rad, p, phlev, surface['temperature'], lp, timestep=timestep)
             return T_con, surface['temperature']

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -237,8 +237,10 @@ class RCE:
                 # adjust CO2 concentrations to find a equilibrium state using
                 # equation 8 of Romps 2020
                 n0 = self.surface.heat_sink
+                A = 5.35
+                tau = 1
                 self.atmosphere['CO2'] += self.timestep * (
-                    n0 - self.radiation['toa'][0]) / 5.35 * self.atmosphere['CO2']
+                    n0 - self.radiation['toa'][0]) / (A * tau) * self.atmosphere['CO2']
 
             # Save the old temperature profile. They are compared with
             # adjusted values to check if the model has converged.

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -10,7 +10,7 @@ from konrad import netcdf
 from konrad.radiation import RRTMG
 from konrad.ozone import (Ozone, OzonePressure)
 from konrad.humidity import FixedRH
-from konrad.surface import (Surface, SlabOcean)
+from konrad.surface import (Surface, SlabOcean, FixedTemperature)
 from konrad.cloud import (Cloud, ClearSky)
 from konrad.convection import (Convection, HardAdjustment, RelaxedAdjustment)
 from konrad.lapserate import (LapseRate, MoistLapseRate)
@@ -145,6 +145,11 @@ class RCE:
         self.experiment = experiment
 
         self.is_co2_adjusting = is_co2_adjusting
+        if is_co2_adjusting and not isinstance(surface, FixedTemperature):
+            raise TypeError(
+                "Runs with adjusting CO2 concentration "
+                "require a fixed surface temperature."
+                )
 
         logging.info('Created Konrad object:\n{}'.format(self))
 

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -10,7 +10,7 @@ from konrad import netcdf
 from konrad.radiation import RRTMG
 from konrad.ozone import (Ozone, OzonePressure)
 from konrad.humidity import FixedRH
-from konrad.surface import (Surface, SurfaceHeatCapacity)
+from konrad.surface import (Surface, SlabOcean)
 from konrad.cloud import (Cloud, ClearSky)
 from konrad.convection import (Convection, HardAdjustment, RelaxedAdjustment)
 from konrad.lapserate import (LapseRate, MoistLapseRate)
@@ -110,7 +110,7 @@ class RCE:
 
         self.humidity = FixedRH() if humidity is None else humidity
         self.surface = utils.return_if_type(surface, 'surface',
-                                            Surface, SurfaceHeatCapacity())
+                                            Surface, SlabOcean())
         self.cloud = utils.return_if_type(cloud, 'cloud',
                                           Cloud,
                                           ClearSky(self.atmosphere['plev'].size)


### PR DESCRIPTION
Combined surface classes, allowing a sink of energy to be added also in the fixed surface temperature case. Added an option to adjust the atmospheric CO2, so that equilibrium can be achieved quickly for a set-up with fixed surface temperature, following Romps 2020 "Climate sensitivity and the direct effect of carbon dioxide in a limited-area cloud-resolving model".