### PR TITLE
Move diurnal_cycle specification

### DIFF
--- a/konrad/core.py
+++ b/konrad/core.py
@@ -38,7 +38,8 @@ class RCE:
     def __init__(self, atmosphere, timestep='3h', max_duration='5000d',
                  outfile=None, experiment='RCE', writeevery='1d', delta=1e-4,
                  radiation=None, ozone=None, humidity=None, surface=None,
-                 cloud=None, convection=None, lapserate=None, upwelling=None):
+                 cloud=None, convection=None, lapserate=None, upwelling=None,
+                 diurnal_cycle=False):
         """Set-up a radiative-convective model.
 
         Parameters:
@@ -94,6 +95,8 @@ class RCE:
             upwelling (konrad.upwelling): Upwelling model.
                 Defaults to :class:`konrad.upwelling.NoUpwelling`.
 
+            diurnal_cycle (bool): Toggle diurnal cycle of solar angle.
+
         """
         # Sub-models.
         self.atmosphere = atmosphere
@@ -122,6 +125,7 @@ class RCE:
         self.upwelling = utils.return_if_type(upwelling, 'upwelling',
                                               Upwelling, NoUpwelling())
 
+        self.diurnal_cycle = diurnal_cycle
         self.max_duration = utils.parse_fraction_of_day(max_duration)
         self.timestep = utils.parse_fraction_of_day(timestep)
         self.writeevery = utils.parse_fraction_of_day(writeevery)
@@ -202,7 +206,8 @@ class RCE:
                 # All other iterations are only logged in DEBUG level.
                 logger.debug(f'Enter iteration {self.niter}.')
 
-            self.radiation.adjust_solar_angle(self.get_hours_passed() / 24)
+            if self.diurnal_cycle:
+                self.radiation.adjust_solar_angle(self.get_hours_passed() / 24)
             self.radiation.update_heatingrates(
                 atmosphere=self.atmosphere,
                 surface=self.surface,

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -263,7 +263,7 @@ class RCE:
                 convection=self.convection,
                 timestep=self.timestep,
                 upwelling=self.upwelling,
-                zenith=self.radiation.zenith,
+                zenith=self.radiation.current_solar_angle
             )
 
             # Update the humidity profile.

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -263,7 +263,7 @@ class RCE:
                 convection=self.convection,
                 timestep=self.timestep,
                 upwelling=self.upwelling,
-                zenith=self.radiation.current_solar_angle
+                zenith=self.radiation.zenith,
             )
 
             # Update the humidity profile.

--- a/konrad/radiation/radiation.py
+++ b/konrad/radiation/radiation.py
@@ -37,6 +37,8 @@ class Radiation(Component, metaclass=abc.ABCMeta):
                 The default angle of 47.88 degree results in 342 W/m^2
                 solar insolation at the top of the atmosphere when used
                 together with a solar constant of 510 W/m^2.
+                If a diurnal cycle is used in full konrad runs, this angle
+                represents latitude.
             bias (dict-like): A dict-like object that stores bias
                 corrections for the diagnostic variable specified by its key,
                 e.g. `bias = {'net_htngrt': 2}`.

--- a/konrad/radiation/radiation.py
+++ b/konrad/radiation/radiation.py
@@ -30,25 +30,21 @@ REQUIRED_VARIABLES = [
 
 class Radiation(Component, metaclass=abc.ABCMeta):
     """Abstract base class to define requirements for radiation models."""
-    def __init__(self, latitude=47.88, bias=None):
+    def __init__(self, zenith_angle=47.88, bias=None):
         """
         Parameters:
-            latitude (float): Angle of the sun.
-                For runs without a diurnal cycle this should represent the
-                diurnal mean zenith angle.
+            zenith_angle (float): Zenith angle of the sun.
                 The default angle of 47.88 degree results in 342 W/m^2
                 solar insolation at the top of the atmosphere when used
                 together with a solar constant of 510 W/m^2.
-                For runs with a diurnal cycle, this represents the latitude in
-                the true sense.
             bias (dict-like): A dict-like object that stores bias
                 corrections for the diagnostic variable specified by its key,
                 e.g. `bias = {'net_htngrt': 2}`.
         """
         super().__init__()
 
-        self.latitude = latitude
-        self.zenith = latitude
+        self.zenith_angle = zenith_angle
+        self.current_solar_angle = self.zenith_angle
 
         self._bias = bias
 
@@ -171,6 +167,8 @@ class Radiation(Component, metaclass=abc.ABCMeta):
         """
         # The local zenith angle, calculated from the latitude and longitude.
         # Seasons are not considered.
-        self.zenith = np.rad2deg(np.arccos(
-            np.cos(np.deg2rad(self.latitude)) *
+        solar_angle = np.rad2deg(np.arccos(
+            np.cos(np.deg2rad(self.zenith_angle)) * 
             np.cos(2 * np.pi * time)))
+
+        self.current_solar_angle = solar_angle

--- a/konrad/radiation/radiation.py
+++ b/konrad/radiation/radiation.py
@@ -47,10 +47,7 @@ class Radiation(Component, metaclass=abc.ABCMeta):
         self.zenith_angle = zenith_angle
         self.diurnal_cycle = diurnal_cycle
 
-        if diurnal_cycle:
-            self.current_solar_angle = 0
-        else:
-            self.current_solar_angle = self.zenith_angle
+        self.current_solar_angle = self.zenith_angle
 
         self._bias = bias
 

--- a/konrad/radiation/radiation.py
+++ b/konrad/radiation/radiation.py
@@ -30,14 +30,13 @@ REQUIRED_VARIABLES = [
 
 class Radiation(Component, metaclass=abc.ABCMeta):
     """Abstract base class to define requirements for radiation models."""
-    def __init__(self, zenith_angle=47.88, diurnal_cycle=False, bias=None):
+    def __init__(self, zenith_angle=47.88, bias=None):
         """
         Parameters:
             zenith_angle (float): Zenith angle of the sun.
                 The default angle of 47.88 degree results in 342 W/m^2
                 solar insolation at the top of the atmosphere when used
                 together with a solar constant of 510 W/m^2.
-            diurnal_cycle (bool): Toggle diurnal cycle of solar angle.
             bias (dict-like): A dict-like object that stores bias
                 corrections for the diagnostic variable specified by its key,
                 e.g. `bias = {'net_htngrt': 2}`.
@@ -45,8 +44,6 @@ class Radiation(Component, metaclass=abc.ABCMeta):
         super().__init__()
 
         self.zenith_angle = zenith_angle
-        self.diurnal_cycle = diurnal_cycle
-
         self.current_solar_angle = self.zenith_angle
 
         self._bias = bias
@@ -168,11 +165,6 @@ class Radiation(Component, metaclass=abc.ABCMeta):
         Parameters:
             time (float): Current time [days].
         """
-        # When the diurnal cycle is disabled, use the constant zenith angle.
-        if not self.diurnal_cycle:
-            self.current_solar_angle = self.zenith_angle
-            return
-
         # The local zenith angle, calculated from the latitude and longitude.
         # Seasons are not considered.
         solar_angle = np.rad2deg(np.arccos(

--- a/konrad/radiation/radiation.py
+++ b/konrad/radiation/radiation.py
@@ -30,21 +30,25 @@ REQUIRED_VARIABLES = [
 
 class Radiation(Component, metaclass=abc.ABCMeta):
     """Abstract base class to define requirements for radiation models."""
-    def __init__(self, zenith_angle=47.88, bias=None):
+    def __init__(self, latitude=47.88, bias=None):
         """
         Parameters:
-            zenith_angle (float): Zenith angle of the sun.
+            latitude (float): Angle of the sun.
+                For runs without a diurnal cycle this should represent the
+                diurnal mean zenith angle.
                 The default angle of 47.88 degree results in 342 W/m^2
                 solar insolation at the top of the atmosphere when used
                 together with a solar constant of 510 W/m^2.
+                For runs with a diurnal cycle, this represents the latitude in
+                the true sense.
             bias (dict-like): A dict-like object that stores bias
                 corrections for the diagnostic variable specified by its key,
                 e.g. `bias = {'net_htngrt': 2}`.
         """
         super().__init__()
 
-        self.zenith_angle = zenith_angle
-        self.current_solar_angle = self.zenith_angle
+        self.latitude = latitude
+        self.zenith = latitude
 
         self._bias = bias
 
@@ -167,8 +171,6 @@ class Radiation(Component, metaclass=abc.ABCMeta):
         """
         # The local zenith angle, calculated from the latitude and longitude.
         # Seasons are not considered.
-        solar_angle = np.rad2deg(np.arccos(
-            np.cos(np.deg2rad(self.zenith_angle)) * 
+        self.zenith = np.rad2deg(np.arccos(
+            np.cos(np.deg2rad(self.latitude)) *
             np.cos(2 * np.pi * time)))
-
-        self.current_solar_angle = solar_angle

--- a/konrad/radiation/rrtmg.py
+++ b/konrad/radiation/rrtmg.py
@@ -22,13 +22,7 @@ class RRTMG(Radiation):
                  **kwargs):
         """
         Parameters:
-            zenith_angle (float): angle of the Sun [degrees].
-
-            diurnal_cycle (bool):
-
-                * :code:`True`  include a diurnal cycle
-
-                * :code:`False`  have a constant Sun
+            latitude (float): angle of the Sun [degrees].
 
             bias (dict-like): include bias corrections to the fluxes and/or
                 heating rates
@@ -234,7 +228,7 @@ class RRTMG(Radiation):
 
         if sw:  # properties required only for shortwave
             state0['zenith_angle'] = DataArray(
-                np.array(np.deg2rad(self.current_solar_angle)),
+                np.array(np.deg2rad(self.zenith)),
                 attrs={'units': 'radians'})
 
         return state0

--- a/konrad/radiation/rrtmg.py
+++ b/konrad/radiation/rrtmg.py
@@ -22,7 +22,13 @@ class RRTMG(Radiation):
                  **kwargs):
         """
         Parameters:
-            latitude (float): angle of the Sun [degrees].
+            zenith_angle (float): angle of the Sun [degrees].
+
+            diurnal_cycle (bool):
+
+                * :code:`True`  include a diurnal cycle
+
+                * :code:`False`  have a constant Sun
 
             bias (dict-like): include bias corrections to the fluxes and/or
                 heating rates
@@ -228,7 +234,7 @@ class RRTMG(Radiation):
 
         if sw:  # properties required only for shortwave
             state0['zenith_angle'] = DataArray(
-                np.array(np.deg2rad(self.zenith)),
+                np.array(np.deg2rad(self.current_solar_angle)),
                 attrs={'units': 'radians'})
 
         return state0

--- a/konrad/radiation/rrtmg.py
+++ b/konrad/radiation/rrtmg.py
@@ -23,12 +23,10 @@ class RRTMG(Radiation):
         """
         Parameters:
             zenith_angle (float): angle of the Sun [degrees].
-
-            diurnal_cycle (bool):
-
-                * :code:`True`  include a diurnal cycle
-
-                * :code:`False`  have a constant Sun
+            In konrad, with no diurnal cycle, this should represent a diurnal
+            mean zenith angle. With a diurnal cycle, this represents latitude.
+            For single radiation calculations, this is the angle to the Sun at
+            the time and location of interest.
 
             bias (dict-like): include bias corrections to the fluxes and/or
                 heating rates


### PR DESCRIPTION
Avoid confusion about the solar constant and zenith angle for radiative flux calculations outside of konrad.