### PR TITLE
Add Python 3.8 support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu, macos]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
         include:
           - name: ubuntu

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,6 +38,20 @@ jobs:
           pip install wheel Cython sympl==0.4.0
           CC=gcc-6 TARGET=HASWELL python setup.py develop --no-deps
 
+      - name: Install CliMT (Python >3.8)
+        if: matrix.name == 'ubuntu' && matrix.python-version > 3.7
+        run: |
+          sudo apt update
+          sudo apt install gcc-6 gfortran-6
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 20
+          sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-6 20
+
+          git clone --branch=v.0.16.9 --depth=1 https://github.com/climt/climt
+          cd climt
+          python -m pip install --upgrade pip
+          pip install wheel Cython sympl==0.4.0
+          python setup.py develop --no-deps
+
       - name: Install
         run: |
           python -m pip install --upgrade pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ sphinx:
 
 # Pyhton settings
 python:
-  version: 3.6
+  version: 3.7
   install:
       - method: pip
         path: .

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     python_requires='>=3.6',
     include_package_data=True,


### PR DESCRIPTION
This PR:
* Adds the Python 3.8 classifier
* Enables automated testing for Python 3.8
* Builds the documentation on Python 3.7 instead of 3.6