### PR TITLE
Improve config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 config/* linguist-vendored
 *.ipynb linguist-language=python
+*.ipynb -diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+docs/build/
+docs/source/_autosummary
 dist/
 *.log
 *.nc


### PR DESCRIPTION
This PR:
* makes git ignore the sphinx build directory
* prevents git from diffing Jupyter notebooks (they are treated like binary files)