### PR TITLE
Optimize netCDF output

### DIFF
--- a/konrad/netcdf.py
+++ b/konrad/netcdf.py
@@ -76,9 +76,11 @@ class NetcdfHandler:
     def create_variable(self, group, name, value, dims=()):
         value = convert_unsupported_types(value)
 
+        dtype = np.asarray(value).dtype.name
         variable = group.createVariable(
             varname=name,
-            datatype=np.asarray(value).dtype,
+            # Store double variables in single precision to save disk space.
+            datatype="float32" if dtype == "float64" else dtype,
             dimensions=dims,
             zlib=True,
         )

--- a/konrad/netcdf.py
+++ b/konrad/netcdf.py
@@ -80,6 +80,7 @@ class NetcdfHandler:
             varname=name,
             datatype=np.asarray(value).dtype,
             dimensions=dims,
+            zlib=True,
         )
         variable[:] = value
 


### PR DESCRIPTION
This PR:
* Enables compression for netCDF files
* Stores `double` variables in single precision

In total, both measures reduce the file size by about 70%.