### PR TITLE
Fix data type check for strings when writing netCDF

### DIFF
--- a/konrad/netcdf.py
+++ b/konrad/netcdf.py
@@ -76,7 +76,7 @@ class NetcdfHandler:
     def create_variable(self, group, name, value, dims=()):
         value = convert_unsupported_types(value)
 
-        dtype = np.asarray(value).dtype.name
+        dtype = np.asarray(value).dtype
         variable = group.createVariable(
             varname=name,
             # Store double variables in single precision to save disk space.


### PR DESCRIPTION
The old implementation lead to an error when determining the str type:
NumPy adds the byte length of strings to the dtype name (e.g. "str320").
This causes the netCDF library to crash.