### PR TITLE
Improve Surface documentation

### DIFF
--- a/konrad/core.py
+++ b/konrad/core.py
@@ -101,7 +101,7 @@ class RCE:
                 Defaults to :class:`konrad.humidity.FixedRH`.
 
             surface (konrad.surface): Surface model.
-                Defaults to :class:`konrad.surface.SurfaceHeatCapacity`.
+                Defaults to :class:`konrad.surface.SlabOcean`.
 
             cloud (konrad.cloud): Cloud model.
                 Defaults to :class:`konrad.cloud.ClearSky`.

--- a/konrad/surface.py
+++ b/konrad/surface.py
@@ -112,9 +112,10 @@ class Surface(Component, metaclass=abc.ABCMeta):
 
             t = dataset['temperature'][timestep].data
             z = float(dataset['height'][:])
+            alb = float(dataset['albedo'][:])
+            le = float(dataset['longwave_emissivity'][:])
 
-        # TODO: Should other variables (e.g. albedo) also be read?
-        return cls(temperature=t, height=z, **kwargs)
+        return cls(temperature=t, height=z, albedo=alb, longwave_emissivity=le, **kwargs)
 
 
 class SlabOcean(Surface):
@@ -163,6 +164,29 @@ class SlabOcean(Surface):
                                 self.heat_capacity)
 
         logger.debug("Surface temperature: {self['temperature'][0]:.4f} K")
+
+    @classmethod  
+    def from_netcdf(cls, ncfile, timestep=-1, **kwargs):
+        """Create a surface model from a netCDF file.
+
+        Parameters:
+            ncfile (str): Path to netCDF file.
+            timestep (int): Timestep to read (default is last timestep).
+        """
+        with netCDF4.Dataset(ncfile) as root:
+            if 'surface' in root.groups:
+                dataset = root['surface']
+            else:
+                dataset = root
+
+            t = dataset['temperature'][timestep].data
+            z = float(dataset['height'][:])
+            alb = float(dataset['albedo'][:])
+            le = float(dataset['longwave_emissivity'][:])
+            hs = float(dataset['heat_sink'][:])
+            d = float(dataset['depth'][:])
+            
+        return cls(temperature=t, height=z, albedo=alb, longwave_emissivity=le, heat_sink=hs, depth=d, **kwargs)
 
 
 class FixedTemperature(Surface):

--- a/konrad/surface.py
+++ b/konrad/surface.py
@@ -2,7 +2,7 @@
 """This module contains classes describing different surfaces.
 
 A surface is required by both the radiation and the convective models used
-inside the RCE simulations.
+inside the RCE simulations, and if you don't set it up default will be a `SlabOcean`.
 
 **Example**
 
@@ -46,10 +46,10 @@ class Surface(Component, metaclass=abc.ABCMeta):
         """Initialize a surface model.
 
         Parameters:
-            albedo (float): Surface albedo. The default value of 0.2 is a
+            albedo (float): Surface albedo [1]. The default value of 0.2 is a
                 decent choice for clear-sky simulation in the tropics.
             temperature (int / float): Surface temperature [K].
-            longwave_emissivity (float): Longwave emissivity.
+            longwave_emissivity (float): Longwave emissivity [1].
             height (int / float): Surface height [m].
         """
         self.albedo = albedo
@@ -128,7 +128,8 @@ class SlabOcean(Surface):
                 the extra-tropics.
             depth (float): Ocean depth [m].
             albedo (float): Surface albedo [1].
-            temperature (float): Surface temperature [K].
+            temperature (float): Initial surface temperature [K].
+            longwave_emissivity (float): Longwave emissivity [1].
             height (float): Surface height [m].
         """
         super().__init__(*args, **kwargs)
@@ -164,9 +165,18 @@ class SlabOcean(Surface):
         logger.debug("Surface temperature: {self['temperature'][0]:.4f} K")
 
 
-class FixedTemperature(SlabOcean):
+class FixedTemperature(Surface):
     """Surface model with fixed temperature."""
     def __init__(self, *args, **kwargs):
+        """Initialize a surface model with constant surface temperature.
+
+        Parameters:
+            albedo (float): Surface albedo. The default value of 0.2 is a
+                decent choice for clear-sky simulation in the tropics.
+            temperature (int / float): Surface temperature [K].
+            longwave_emissivity (float): Longwave emissivity.
+            height (int / float): Surface height [m].
+        """
         super().__init__(*args, **kwargs)
         self.heat_capacity = np.inf
 


### PR DESCRIPTION
- Change the inheritance of FixedTemperature to Surface and not SlabSurface (there was no apparent reason for having in inheriting from SlabSurface as the new attribute of SlabSurface are not used in FixedTemperature)
- Update/change docstrings in Surface and Core.
- Make the from_netcdf method read all parameters for the class, and add a overloading method in SlabOcean for the new parameters.