### PR TITLE
Fix data type handling when reading netCDF files

### DIFF
--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -1,0 +1,32 @@
+{{ name }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+      :noindex:
+
+   {% if methods %}
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree:
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,8 +14,17 @@ Core Model
 
    konrad.core
 
-Submodules
-----------
+Model components
+----------------
+
+Abstract base class for all model components.
+
+.. toctree::
+   :maxdepth: 1
+
+   konrad.component
+
+Model components to configure the configuration of `konrad`.
 
 .. toctree::
    :maxdepth: 1
@@ -38,7 +47,6 @@ Miscellaneous
 .. toctree::
    :maxdepth: 1
 
-   konrad.component
    konrad.netcdf
    konrad.physics
    konrad.utils

--- a/konrad/atmosphere.py
+++ b/konrad/atmosphere.py
@@ -158,8 +158,7 @@ class Atmosphere(Component):
         """
 
         def _return_profile(ds, var, ts):
-            return (ds[var][ts, :] if 'time' in ds[var].dimensions
-                    else ds[var][:])
+            return ds[var][ts, :] if 'time' in ds[var].dimensions else ds[var][:]
 
         with netCDF4.Dataset(ncfile) as root:
             if 'atmosphere' in root.groups:
@@ -167,10 +166,10 @@ class Atmosphere(Component):
             else:
                 dataset = root
 
-            datadict = {var: np.array(_return_profile(dataset, var, timestep))
-                        for var in cls.atmosphere_variables
-                        if var in dataset.variables
-                        }
+            datadict = {
+                var: np.array(_return_profile(dataset, var, timestep), dtype="float64")
+                for var in cls.atmosphere_variables if var in dataset.variables
+            }
             datadict['phlev'] = np.array(root['phlev'][:])
 
         return cls.from_dict(datadict)

--- a/konrad/component.py
+++ b/konrad/component.py
@@ -39,6 +39,27 @@ class Component:
 
         return instance
 
+    @classmethod
+    def from_netcdf(cls, ncfile, timestep=-1, *args, **kwargs):
+        """Load a model component from a netCDF file.
+
+        Note:
+            The :class:`konrad.netcdf.NetcdfHandler` converts variables
+            of type `double` variables into `float` to reduce disk space.
+            However, the underlying `climt` library requires input
+            for :class:`konrad.radiation.RRTMG` to be of type `double`.
+            Make sure to perform the respective typecasting
+            when reading variables from netCDF files.
+
+        Parameters:
+            ncfile (str): Path to the netCDF file.
+            timestep (int): Index of timestep to read.
+
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} does not support reading of netCDF files."
+        )
+
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)
 

--- a/konrad/netcdf.py
+++ b/konrad/netcdf.py
@@ -39,6 +39,13 @@ def convert_unsupported_types(variable):
 class NetcdfHandler:
     """A netCDF file handler.
 
+    Note:
+        The netCDF handler typecasts variables from ``double`` into ``float``
+        in order to save disk space.
+        Developers need to convert variables back into ``double``
+        when implementing ``konrad.component.Component.from_netcdf()``
+        methods for model components.
+
     Usage:
         >>> rce = konrad.RCE(...)
         >>> nc = NetcdfHandler('output.nc', rce)  # create output file

--- a/konrad/surface.py
+++ b/konrad/surface.py
@@ -110,7 +110,7 @@ class Surface(Component, metaclass=abc.ABCMeta):
             else:
                 dataset = root
 
-            t = dataset['temperature'][timestep].data
+            t = dataset['temperature'][timestep].data.astype("float64")
             z = float(dataset['height'][:])
             alb = float(dataset['albedo'][:])
             le = float(dataset['longwave_emissivity'][:])
@@ -179,7 +179,7 @@ class SlabOcean(Surface):
             else:
                 dataset = root
 
-            t = dataset['temperature'][timestep].data
+            t = dataset['temperature'][timestep].data.astype("float64")
             z = float(dataset['height'][:])
             alb = float(dataset['albedo'][:])
             le = float(dataset['longwave_emissivity'][:])


### PR DESCRIPTION
This PR:
* fixes the handling of `float` and `double` data types in netCDF
* adds documentation on why variables are stored as `float` and that they need to be converted into `double` when reading
* adds static pages for methods to the documentation