### PR TITLE
Atmosphere method `from_netcdf`: Added conversion to double precision also for pressure levels

### DIFF
--- a/konrad/atmosphere.py
+++ b/konrad/atmosphere.py
@@ -170,7 +170,7 @@ class Atmosphere(Component):
                 var: np.array(_return_profile(dataset, var, timestep), dtype="float64")
                 for var in cls.atmosphere_variables if var in dataset.variables
             }
-            datadict['phlev'] = np.array(root['phlev'][:])
+            datadict['phlev'] = np.array(root['phlev'][:], dtype="float64")
 
         return cls.from_dict(datadict)
 


### PR DESCRIPTION
When creating an atmosphere from a netCDF file, data should be converted to double precision.  It is implemented for all variables except for pressure levels.

With this modification, restarts from past experiments now work as expected.