### PR TITLE
Proposal of convergence tests using temperature and net radiative flux change at the TOA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *so.1
 .idea
 .ipynb_checkpoints
+konrad.egg-info/*


### PR DESCRIPTION
Added convergence test in terms of the temperature and the net
radiative flux at the TOA. Additions on file `core.py`

1) Added class attributes initialised to `None`: `delta2`, `deltaT` and
   `deltaN` (lines 180,181).

2) Added the test for the net radiative flux at the TOA in the
   class method `is_converged()`.

   The model only converges if both the temperature and net
   radiative flux at TOA fulfill their convergence criteria.

3) Added calculation of the old net radiative flux at the TOA
   (lines 278-291).

4) Added a calculation of a specific convergence threshold for the
   net radiative flux at the TOA (lines 379-383).

5) Added calculation of the net radiative flux change at the TOA
   (lines 385-396).

6) Added logger entries to check the status of the temperature and
   the net radiative flux changes (lines 397-403).