### PR TITLE
Simplify installation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,31 +28,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install CliMT (MacOS)
+      - name: Install GCC (MacOS)
         if: matrix.name == 'macos'
         run: |
           brew install gcc@10
-          git clone --branch=v.0.16.9 --depth=1 https://github.com/climt/climt
-          cd climt
-          python -m pip install --upgrade pip
-          pip install wheel Cython sympl==0.4.0
-          CC=gcc-10 FC=gfortran-10 TARGET=HASWELL python setup.py develop --no-deps
-
-      - name: Install CliMT (Python >3.8)
-        if: matrix.name == 'ubuntu' && matrix.python-version > 3.7
-        run: |
-          gcc --version
-          gfortran --version
-          git clone --branch=v.0.16.9 --depth=1 https://github.com/climt/climt
-          cd climt
-          python -m pip install --upgrade pip
-          pip install wheel Cython sympl==0.4.0
-          python setup.py develop --no-deps
+          echo "::set-env name=CC::gcc-10"
+          echo "::set-env name=FC::gfortran-10"
 
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install .[docs,tests]
+          pip install wheel
+          TARGET=HASWELL pip install .[docs,tests]
           pip list
 
       - name: Lint with flake8

--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ You can install the latest stable version of ``konrad`` using ``pip``:
 ```bash
 pip install konrad
 ```
+
+Konrad depends on the [CliMT](https://github.com/CliMT/climt) package.
+CliMT handles a variety of underlying FORTRAN code and provides precompiled
+binary wheels for some Python versions and operating systems.
+
+### Python >3.7
+However, for Python >3.7 the FORTRAN libraries need to be compiled locally.
+In this case, you need to specify a C compiler, a FORTRAN compiler, and the
+target architecture using the corresponding environment variables:
+```bash
+CC=gcc FC=gfortran TARGET=HASWELL pip install konrad
+```
+
+### macOS
+On macOS, you may need to install the GCC compiler suite beforehand:
+```bash
+brew install gcc@10
+CC=gcc-10 FC=gfortran-10 TARGET=HASWELL pip install konrad
+```

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'matplotlib>=2.0.0',
         'netcdf4>=1.2.7',
-        'numpy>=1.16.1',
+        'numpy>=1.16.0',
         'scipy>=0.19.0',
         'typhon>=0.7.0',
         'xarray>=0.9.1',


### PR DESCRIPTION
This PR:
* simplifies the installation for Python version for which CliMT does not provide binary wheels
* extends the description of the installation in the top-level README file