### PR TITLE
Make rce write to ouput file at 1st time step

### DIFF
--- a/konrad/core.py
+++ b/konrad/core.py
@@ -242,7 +242,8 @@ class RCE:
         if self.outfile is None:
             return False
 
-        if (self.time - self.last_written) >= self.writeevery:
+        if ((self.time - self.last_written) >= self.writeevery
+           or self.time == datetime.datetime(1, 1, 1)):
             self.last_written = self.time
             return True
         else:


### PR DESCRIPTION
It is problematic that the first time `RCE.run()` writes to the outputfile is after `self.writeevery` days and not in the beginning. I had some runs where the surface temperature strongly changed within the first day(s), which distorts the Gregoryplot, because in the netcdf file `surface['temperature'][0]` is not the surface temperature at the beginning of the simulation, but when the first value is written. The same is true for fluxes and can lead to an incorrect estimate for the effective forcing and total temperature change in scenarios with fast changes in the very beginning. The climate sensitivity parameter should be unaffected, because it only depends on the slope.
Writing out in the 1st time step solves this problem.

I can provide graphs for illustrating this if needed. So far it didn't make a big difference for CO2 forcing, but for aerosol forcing.