### PR TITLE
Change directory name from "aux" to "data"

### DIFF
--- a/konrad/radiation/arts.py
+++ b/konrad/radiation/arts.py
@@ -98,7 +98,7 @@ class _ARTS:
         # Read lookup table
         abs_lookup = os.getenv(
             "KONRAD_LOOKUP_TABLE",
-            join(dirname(__file__), "aux/abs_lookup.xml")
+            join(dirname(__file__), "data/abs_lookup.xml")
         )
 
         if not isfile(abs_lookup):


### PR DESCRIPTION
Store the ARTS lookup tables in a directory called "data". The former
name "aux" is a reserved name on Windows machines.