### PR TITLE
Fix variable initialization

### DIFF
--- a/konrad/upwelling.py
+++ b/konrad/upwelling.py
@@ -113,6 +113,13 @@ class StratosphericUpwelling(Upwelling):
             convection (konrad.convection): Convection model.
             timestep (float): Timestep width [day].
         """
+        # Ensure that the variable is initialized even if the upwelling is not
+        # applied. A proper initaliziation is needed to write netCDF output.
+        self.create_variable(
+            'cooling_rates',
+            dims=('time', 'plev'),
+            data=np.zeros_like(atmosphere["plev"]).reshape(1, -1),
+        )
 
         T = atmosphere['T'][0, :]
         z = atmosphere['z'][0, :]


### PR DESCRIPTION
This PR fixes the initialization of the `cooling_rates` variable in the `StratosphericUpwelling` class. In some cases - when the upwelling was never actually applied - the old implementation lead to crashes when attempting to write to netCDF.