### PR TITLE
Replace CliMT dependency with our own fork

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
     - pytest
     - pip
     - pip:
-        - climt==0.16.9
+        - git+git://github.com/atmtools/climt@allow-latest-numpy#egg=climt
         - pyarts
         - sympl>=0.4.0
 channels:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'scipy>=0.19.0',
         'typhon>=0.7.0',
         'xarray>=0.9.1',
-        'climt==0.16.9',
+        'climt @ https://api.github.com/repos/atmtools/climt/tarball/allow-latest-numpy',
         'sympl>=0.4.0',
     ],
     extras_require={


### PR DESCRIPTION
The forked version loosens the dependency for NumPy which fixes the
installation on newer system and Python versions.