### PR TITLE
Revise convection

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ Model components to configure the configuration of `konrad`.
    konrad.cloud
    konrad.constants
    konrad.convection
+   konrad.entrainment
    konrad.humidity
    konrad.lapserate
    konrad.ozone

--- a/docs/source/konrad.entrainment.rst
+++ b/docs/source/konrad.entrainment.rst
@@ -1,0 +1,10 @@
+Entrainment
+===========
+
+.. automodule:: konrad.entrainment
+
+.. autosummary::
+   :toctree: _autosummary
+
+   Entrainment
+   NoEntrainment

--- a/docs/source/konrad.entrainment.rst
+++ b/docs/source/konrad.entrainment.rst
@@ -8,3 +8,4 @@ Entrainment
 
    Entrainment
    NoEntrainment
+   ZeroBuoyancyEntrainingPlume

--- a/konrad/__init__.py
+++ b/konrad/__init__.py
@@ -27,6 +27,7 @@ from . import cloud
 from . import component
 from . import constants
 from . import convection
+from . import entrainment
 from . import humidity
 from . import lapserate
 from . import netcdf

--- a/konrad/convection.py
+++ b/konrad/convection.py
@@ -252,7 +252,7 @@ class HardAdjustment(Convection):
         # would not warm the atmosphere, so we do not change the atmospheric
         # temperature profile and calculate the energy change simply from the
         # surface temperature change.
-        surfaceTneg = np.array([np.min(atmosphere["T"])])
+        surfaceTneg = atmosphere["T"][0, 0]
         eff_Cp_s = surface.heat_capacity
         diff_neg = eff_Cp_s * (surfaceTneg - surface['temperature'])
         if np.abs(diff_neg) < near_zero:

--- a/konrad/convection.py
+++ b/konrad/convection.py
@@ -21,6 +21,7 @@ import abc
 import numpy as np
 import typhon
 from scipy.interpolate import interp1d
+from scipy.integrate import ode
 
 from konrad import constants
 from konrad.component import Component
@@ -133,6 +134,17 @@ def pressure_lapse_rate(p, phlev, T, lapse):
     return lp
 
 
+def pressure_lapse(func):
+    """Decorator to convert dTdz(p, T) into dTdP(p, T)."""
+
+    def _wrapper(p, T):
+        g = constants.earth_standard_gravity
+        rho = typhon.physics.density(p, T)
+        return func(p, T) / (g * rho)
+
+    return _wrapper
+
+
 class Convection(Component, metaclass=abc.ABCMeta):
     """Base class to define abstract methods for convection schemes."""
     @abc.abstractmethod
@@ -140,10 +152,11 @@ class Convection(Component, metaclass=abc.ABCMeta):
         """Stabilize the temperature profile by redistributing energy.
 
         Parameters:
-              atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
-              lapse (ndarray): Temperature lapse rate [K/day].
-              surface (konrad.surface): Surface model.
-              timestep (float): Timestep width [day].
+            atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
+            lapse (konrad.lapsereate.LapseRate): Callable `f(p, T)` that
+                returns a temperature lapse rate in [K/day].
+            surface (konrad.surface): Surface model.
+            timestep (float): Timestep width [day].
         """
 
 
@@ -156,15 +169,12 @@ class NonConvective(Convection):
 class HardAdjustment(Convection):
     """Instantaneous adjustment of temperature profiles"""
     def stabilize(self, atmosphere, lapse, surface, timestep):
-
         T_rad = atmosphere['T'][0, :]
         p = atmosphere['plev']
 
         # Find convectively adjusted temperature profile.
         T_new, T_s_new = self.convective_adjustment(
-            p=p,
-            phlev=atmosphere['phlev'],
-            T_rad=T_rad,
+            atmosphere=atmosphere,
             lapse=lapse,
             surface=surface,
             timestep=timestep,
@@ -175,8 +185,7 @@ class HardAdjustment(Convection):
         atmosphere['T'][0, :] = T_new
         surface['temperature'][0] = T_s_new
 
-    def convective_adjustment(self, p, phlev, T_rad, lapse, surface,
-                              timestep=0.1):
+    def convective_adjustment(self, atmosphere, lapse, surface, timestep=0.1):
         """
         Find the energy-conserving temperature profile using upper and lower
         bound profiles (calculated from surface temperature extremes: no change
@@ -186,11 +195,9 @@ class HardAdjustment(Convection):
         conservation.
 
         Parameters:
-            p (ndarray): pressure levels [Pa]
-            phlev (ndarray): half pressure levels [Pa]
-            T_rad (ndarray): old atmospheric temperature profile [K]
-            lapse (ndarray): critical lapse rate [K/m] defined on pressure
-                half-levels
+            atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
+            lapse (konrad.lapsereate.LapseRate): Callable `f(p, T)` that
+                returns a temperature lapse rate in [K/day].
             surface (konrad.surface):
                 surface associated with old temperature profile
             timestep (float): only required for slow convection [days]
@@ -199,27 +206,25 @@ class HardAdjustment(Convection):
             ndarray: atmospheric temperature profile [K]
             float: surface temperature [K]
         """
-        lp = pressure_lapse_rate(p, phlev, T_rad, lapse)
-
         # This is the temperature profile required if we have a set-up with a
         # fixed surface temperature. In this case, energy is not conserved.
         if isinstance(surface, FixedTemperature):
             T_con = self.convective_profile(
-                T_rad, p, phlev, surface['temperature'], lp, timestep=timestep)
+                atmosphere, surface['temperature'], lapse, timestep=timestep)
             return T_con, surface['temperature']
 
         # Otherwise we should conserve energy --> our energy change should be
         # less than the threshold 'near_zero'.
         # The threshold is scaled with the effective heat capacity of the
         # surface, ensuring that very thick surfaces reach the target.
-        near_zero = float(surface.heat_capacity / 1e13)
+        near_zero = float(surface.heat_capacity / 1e10)
 
         # Find the energy difference if there is no change to surface temp due
         # to convective adjustment. In this case the new profile should be
         # associated with an increase in energy in the atmosphere.
         surfaceTpos = surface['temperature']
         T_con, diff_pos = self.create_and_check_profile(
-            T_rad, p, phlev, surface, surfaceTpos, lp, timestep=timestep)
+            atmosphere, surface, surfaceTpos, lapse, timestep=timestep)
 
         # For other cases, if we find a decrease or approx no change in energy,
         # the atmosphere is not being warmed by the convection,
@@ -236,7 +241,7 @@ class HardAdjustment(Convection):
         # would not warm the atmosphere, so we do not change the atmospheric
         # temperature profile and calculate the energy change simply from the
         # surface temperature change.
-        surfaceTneg = np.array([np.min(T_rad)])
+        surfaceTneg = np.array([np.min(atmosphere["T"])])
         eff_Cp_s = surface.heat_capacity
         diff_neg = eff_Cp_s * (surfaceTneg - surface['temperature'])
         if np.abs(diff_neg) < near_zero:
@@ -254,7 +259,7 @@ class HardAdjustment(Convection):
             # Calculate temperature profile and energy change associated with
             # this surface temperature.
             T_con, diff = self.create_and_check_profile(
-                T_rad, p, phlev, surface, surfaceT, lp, timestep=timestep)
+                atmosphere, surface, surfaceT, lapse, timestep=timestep)
 
             # Update either upper or lower bound.
             if diff > 0:
@@ -273,7 +278,8 @@ class HardAdjustment(Convection):
 
         return T_con, surfaceT
 
-    def convective_profile(self, T_rad, p, phlev, surfaceT, lp, **kwargs):
+    @staticmethod
+    def get_moist_adiabat(atmosphere, surfaceT, lapse, **kwargs):
         """
         Assuming a particular surface temperature (surfaceT), create a new
         profile, following the specified lapse rate (lp) for the region where
@@ -282,39 +288,54 @@ class HardAdjustment(Convection):
         the stratosphere.
 
         Parameters:
-            T_rad (ndarray): radiative temperature profile [K]
-            p (ndarray): pressure levels [Pa]
-            phlev (ndarray): pressure half-levels [Pa]
+            atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
             surfaceT (float): surface temperature [K]
-            lp (ndarray): pressure lapse rate [K/Pa]
+            lapse (konrad.lapsereate.LapseRate): Callable `f(p, T)` that
+                returns a temperature lapse rate in [K/day].
 
         Returns:
              ndarray: convectively adjusted temperature profile [K]
         """
-        # for the lapse rate integral use a different dp, considering that the
-        # lapse rate is given on half levels
-        dp_lapse = np.hstack((np.array([p[0] - phlev[0]]), np.diff(p)))
-        T_con = surfaceT - np.cumsum(dp_lapse * lp)
+        # Kudos to Jiawei Bao for this neat implementation of the dTdp integration!
+        p = atmosphere["plev"]
+        ph = atmosphere["phlev"]
+        Ts = surfaceT
+
+        r = ode(pressure_lapse(lapse)).set_integrator('lsoda', atol=1e-4)
+        r.set_initial_value(Ts, ph[0])
+
+        T = np.zeros_like(p)
+        i = 0
+        dp = np.hstack((np.array([p[0] - ph[0]]), np.diff(p)))
+        while r.successful() and r.t > p.min():
+            r.integrate(r.t + dp[i])
+            T[i] = r.y[0]
+            i += 1
+
+        return T
+
+    def convective_profile(self, atmosphere, surfaceT, lapse, **kwargs):
+        # The convective adjustment is only applied to the atmospheric profile,
+        # if it causes heating somewhere
+        T_rad = atmosphere["T"][-1]
+        T_con = self.get_moist_adiabat(atmosphere, surfaceT, lapse)
 
         if np.any(T_con > T_rad):
             contop = np.max(np.where(T_con > T_rad))
             T_con[contop+1:] = T_rad[contop+1:]
         else:
-            # convective adjustment is only applied to the atmospheric profile,
-            # if it causes heating somewhere
-            T_con = T_rad
+            return T_rad
 
         return T_con
 
-    def create_and_check_profile(self, T_rad, p, phlev, surface, surfaceT, lp,
+
+    def create_and_check_profile(self, atmosphere, surface, surfaceT, lapse,
                                  timestep=0.1):
         """Create a convectively adjusted temperature profile and calculate how
         close it is to satisfying energy conservation.
 
         Parameters:
-            T_rad (ndarray): old atmospheric temperature profile
-            p (ndarray): pressure levels
-            phlev (ndarray): half pressure levels
+            atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
             surface (konrad.surface):
                 surface associated with old temperature profile
             surfaceT (float): surface temperature of the new profile
@@ -325,13 +346,14 @@ class HardAdjustment(Convection):
             ndarray: new atmospheric temperature profile
             float: energy difference between the new profile and the old one
         """
-        T_con = self.convective_profile(T_rad, p, phlev, surfaceT, lp,
+        T_rad = atmosphere["T"][-1]
+        T_con = self.convective_profile(atmosphere, surfaceT, lapse,
                                         timestep=timestep)
 
         eff_Cp_s = surface.heat_capacity
 
         diff = energy_difference(T_con, T_rad, surfaceT,
-                                 surface['temperature'], phlev, eff_Cp_s)
+                                 surface['temperature'], atmosphere["phlev"], eff_Cp_s)
         return T_con, float(diff)
 
     def update_convective_top(self, T_rad, T_con, p, timestep=0.1, lim=0.2):
@@ -426,7 +448,7 @@ class RelaxedAdjustment(HardAdjustment):
 
         return tau
 
-    def convective_profile(self, T_rad, p, phlev, surfaceT, lp, timestep):
+    def convective_profile(self, atmosphere, surfaceT, lapse, timestep):
         """
         Assuming a particular surface temperature (surfaceT), create a new
         profile, which tries to follow the specified lapse rate (lp). How close
@@ -434,23 +456,18 @@ class RelaxedAdjustment(HardAdjustment):
         timescale and model timestep.
 
         Parameters:
-            T_rad (ndarray): radiative temperature profile [K]
-            p (ndarray): pressure levels [Pa]
-            phlev (ndarray): pressure half-levels [Pa]
+            atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
             surfaceT (float): surface temperature [K]
-            lp (ndarray): pressure lapse rate [K/Pa]
+            lapse (konrad.lapsereate.LapseRate): Callable `f(p, T)` that
+                returns a temperature lapse rate in [K/day].
             timestep (float/int): model timestep [days]
 
         Returns:
              ndarray: convectively adjusted temperature profile [K]
         """
-        # For the lapse rate integral use a dp, which takes into account that
-        # the lapse rate is given on the model half-levels.
-        dp_lapse = np.hstack((np.array([p[0] - phlev[0]]), np.diff(p)))
+        T_con = self.get_moist_adiabat(atmosphere, surfaceT, lapse)
 
-        tau = self.get_convective_tau(p)
-
+        tau = self.get_convective_tau(atmosphere["plev"])
         tf = 1 - np.exp(-timestep / tau)
-        T_con = T_rad * (1 - tf) + tf * (surfaceT - np.cumsum(dp_lapse * lp))
 
-        return T_con
+        return atmosphere["T"][0] * (1 - tf) + tf * T_con

--- a/konrad/core.py
+++ b/konrad/core.py
@@ -386,17 +386,13 @@ class RCE():
             # Saves the old temperature (time step adjustment)
             self.oldT = self.atmosphere['T'][0].copy()
 
-            # Calculates the critical lapse rate with the present state
-            critical_lapserate = self.lapserate(self.atmosphere)
-
             # Applies radiative heating rates to the temperature profile
-            self.atmosphere['T'] += (self.radiation['net_htngrt'] *
-                                     self.timestep_days)
+            self.atmosphere['T'] += (self.radiation['net_htngrt'] * self.timestep_days)
 
             # Performs the convective adjustment of the temperature profile
             self.convection.stabilize(
                 atmosphere=self.atmosphere,
-                lapse=critical_lapserate,
+                lapse=self.lapserate,
                 timestep=self.timestep_days,
                 surface=self.surface,
             )

--- a/konrad/entrainment.py
+++ b/konrad/entrainment.py
@@ -1,0 +1,27 @@
+"""This module contains classes for an entrainment induced cooling term.
+"""
+import abc
+
+from konrad.component import Component
+
+
+class Entrainment(Component, metaclass=abc.ABCMeta):
+    """Base class to define abstract methods for all entrainment handlers."""
+
+    @abc.abstractmethod
+    def entrain(self, T, atmosphere):
+        """Entrain air masses to the atmosphere column.
+
+        Parameters:
+            atmosphere (konrad.atmosphere.Atmosphere): Atmosphere model.
+            timestep (float): Timestep width [day].
+
+        Returns:
+            ndarray: Adjusted temperature profile [K].
+        """
+
+
+class NoEntrainment(Entrainment):
+    """Do not entrain air."""
+    def entrain(self, T, *args, **kwargs):
+        return T

--- a/konrad/entrainment.py
+++ b/konrad/entrainment.py
@@ -2,7 +2,13 @@
 """
 import abc
 
+import numpy as np
+from scipy.interpolate import interp1d
+from typhon.physics import vmr2mixing_ratio
+
+from konrad import constants
 from konrad.component import Component
+from konrad.physics import saturation_pressure, vmr2relative_humidity
 
 
 class Entrainment(Component, metaclass=abc.ABCMeta):
@@ -23,5 +29,87 @@ class Entrainment(Component, metaclass=abc.ABCMeta):
 
 class NoEntrainment(Entrainment):
     """Do not entrain air."""
+
     def entrain(self, T, *args, **kwargs):
         return T
+
+
+class ZeroBuoyancyEtrainingPlume(Entrainment):
+    """Zero-buoyancy entraining plume.
+
+    Adjustment with a lapse rate affected by entrainment below the freezing level.
+    Following moist-adiabat at the upper (T_con=T_rad)  and lower boundaries (surface).
+    Reduced temperature in between, minimum at freezing level (273.15 kelvin).
+    Temperature reduction from entrainment following the zero-buoyancy entraining plume
+    model as described by Singh&O'Gorman (2013).
+    """
+
+    def __init__(self, entr=0.5):
+        """Initialize the entrainment component.
+
+        entr (float): Entrainment parameter.
+        """
+        self.entr = entr
+
+    def entrain(self, T_con_adiabat, atmosphere):
+        # Physical constants.
+        L = constants.heat_of_vaporization
+        Rv = constants.specific_gas_constant_water_vapor
+        Cp = constants.isobaric_mass_heat_capacity_dry_air
+
+        # Abbreviated variables references.
+        T_rad = atmosphere["T"][0, :]
+        p = atmosphere["plev"][:]
+        phlev = atmosphere["phlev"][:]
+
+        # Zero-buoyancy plume entrainment.
+        k_ttl = np.max(np.where(T_con_adiabat >= T_rad))
+        r_saturated = np.ones_like(p) * 0.0
+        r_saturated[: k_ttl + 1] = vmr2mixing_ratio(
+            saturation_pressure(T_con_adiabat[: k_ttl + 1]) / p[: k_ttl + 1]
+        )
+        q_saturated = r_saturated / (1 + r_saturated)
+        q_saturated_hlev = interp1d(np.log(p), q_saturated, fill_value="extrapolate")(
+            np.log(phlev[:-1])
+        )
+
+        z = atmosphere["z"][0, :]
+        zhlev = interp1d(np.log(p), z, fill_value="extrapolate")(np.log(phlev[:-1]))
+        dz_lapse = np.hstack((np.array([z[0] - zhlev[0]]), np.diff(z)))
+
+        RH = vmr2relative_humidity(atmosphere["H2O"][0, :], p, atmosphere["T"][0, :])
+        RH = np.where(RH > 1, 1, RH)
+        RH_hlev = interp1d(np.log(p), RH, fill_value="extrapolate")(np.log(phlev[:-1]))
+
+        deltaT = np.ones_like(p) * 0.0
+        k_cb = np.max(np.where(p >= 96000.0))
+        deltaT[k_cb:] = (
+            1
+            / (1 + L / (Rv * T_con_adiabat[k_cb:] ** 2) * L * q_saturated[k_cb:] / Cp)
+            * np.cumsum(
+                self.entr
+                / zhlev[k_cb:]
+                * (1 - RH_hlev[k_cb:])
+                * L
+                / Cp
+                * q_saturated_hlev[k_cb:]
+                * dz_lapse[k_cb:]
+            )
+        )
+
+        k_fl = np.max(np.where(T_con_adiabat - deltaT >= 273.15))
+        p_fl = p[k_fl]
+        p_ttl = p[k_ttl]
+
+        f = lambda x: x ** (1.0 / 1.5)
+        weight = f((p[k_fl : k_ttl + 1] - p_ttl) / (p_fl - p_ttl))
+        deltaT[k_fl : k_ttl + 1] = deltaT[k_fl : k_ttl + 1] * weight
+        deltaT[k_ttl + 1 :] = 0
+
+        self.create_variable(
+            name="entrainment_cooling",
+            dims=("time", "plev"),
+            data=deltaT.reshape(1, -1),
+        )
+
+        return T_con_adiabat - deltaT

--- a/konrad/netcdf.py
+++ b/konrad/netcdf.py
@@ -165,8 +165,8 @@ class NetcdfHandler:
                 if hasattr(attr, "netcdf_subgroups"):
                     for sname, sgroup in attr.netcdf_subgroups.items():
                         self._component_cache[f"{attr_name}/{sname}"] = sgroup
-                else:
-                    self._component_cache[attr_name] = attr
+
+                self._component_cache[attr_name] = attr
 
         logger.debug(f'Components for netCDF file: "{self._component_cache}".')
 


### PR DESCRIPTION
This PR:
* changes the call interface of all `LapseRate` classes -> `lapse(p, T)`.
* revises the convective adjustment to properly integrate the temperate lapse-rate starting from the surface
* adds a conceptual model for entraining dry air masses (based on @jiaweibao implementation)
* fixes an issue when top-level variables in a class were not saved if netCDF subgroups have been defined 