### PR TITLE
Fix lapserate cache

### DIFF
--- a/docs/source/konrad.convection.rst
+++ b/docs/source/konrad.convection.rst
@@ -9,7 +9,6 @@ Convection Scheme
    energy_difference
    latent_heat_difference
    interp_variable
-   pressure_lapse_rate
    Convection
    NonConvective
    HardAdjustment

--- a/docs/source/konrad.lapserate.rst
+++ b/docs/source/konrad.lapserate.rst
@@ -9,3 +9,4 @@ Lapse Rate
    LapseRate
    MoistLapseRate
    FixedLapseRate
+   DryLapseRate

--- a/konrad/convection.py
+++ b/konrad/convection.py
@@ -33,7 +33,6 @@ __all__ = [
     'energy_difference',
     'latent_heat_difference',
     'interp_variable',
-    'pressure_lapse_rate',
     'Convection',
     'NonConvective',
     'HardAdjustment',
@@ -111,28 +110,6 @@ def interp_variable(variable, convective_heating, lim):
 
     # Interpolate the values to where the convective heating rate equals `lim`.
     return interp1d(heat_array, var_array)(lim)
-
-
-def pressure_lapse_rate(p, phlev, T, lapse):
-    """
-    Calculate the pressure lapse rate (change in temperature with pressure)
-    from the height lapse rate (change in temperature with height).
-
-    Parameters:
-        p (ndarray): pressure levels
-        phlev (ndarray): pressure half-levels
-        T (ndarray): temperature profile
-        lapse (ndarray): lapse rate [K/m] defined on pressure half-levels
-    Returns:
-        ndarray: pressure lapse rate [K/Pa]
-    """
-    density_p = typhon.physics.density(p, T)
-    # Interpolate density onto pressure half-levels
-    density = interp1d(p, density_p, fill_value='extrapolate')(phlev[:-1])
-
-    g = constants.earth_standard_gravity
-    lp = -lapse / (g * density)
-    return lp
 
 
 class Convection(Component, metaclass=abc.ABCMeta):

--- a/konrad/convection.py
+++ b/konrad/convection.py
@@ -135,17 +135,6 @@ def pressure_lapse_rate(p, phlev, T, lapse):
     return lp
 
 
-def pressure_lapse(func):
-    """Decorator to convert dTdz(p, T) into dTdP(p, T)."""
-
-    def _wrapper(p, T):
-        g = constants.earth_standard_gravity
-        rho = typhon.physics.density(p, T)
-        return func(p, T) / (g * rho)
-
-    return _wrapper
-
-
 class Convection(Component, metaclass=abc.ABCMeta):
     """Base class to define abstract methods for convection schemes."""
     @abc.abstractmethod
@@ -324,7 +313,7 @@ class HardAdjustment(Convection):
         ph = atmosphere["phlev"]
         Ts = surfaceT
 
-        r = ode(pressure_lapse(lapse)).set_integrator('lsoda', atol=1e-4)
+        r = ode(lapse).set_integrator('lsoda', atol=1e-4)
         r.set_initial_value(Ts, ph[0])
 
         T = np.zeros_like(p)

--- a/konrad/lapserate.py
+++ b/konrad/lapserate.py
@@ -116,3 +116,13 @@ class FixedLapseRate(LapseRate):
 
     def __call__(self, p, T):
         return _to_p_coordinates(self.lapserate, p, T)
+
+
+class DryLapseRate(FixedLapseRate):
+    """Fixed dry-adiabatic lapse rate through the whole atmosphere."""
+    def __init__(self):
+        g = constants.earth_standard_gravity
+        c_p = constants.isobaric_mass_heat_capacity_dry_air
+        gamma_d = g / c_p
+
+        super().__init__(lapserate=gamma_d)

--- a/konrad/lapserate.py
+++ b/konrad/lapserate.py
@@ -41,6 +41,7 @@ def _to_p_coordinates(gamma, p, T):
 
 class LapseRate(Component, metaclass=abc.ABCMeta):
     """Base class for all lapse rate handlers."""
+
     @abc.abstractmethod
     def __call__(self, p, T):
         """Return the atmospheric lapse rate.
@@ -56,6 +57,7 @@ class LapseRate(Component, metaclass=abc.ABCMeta):
 
 class MoistLapseRate(LapseRate):
     """Moist adiabatic temperature lapse rate."""
+
     def __init__(self, fixed=False):
         self._lapse_cache = None
 
@@ -96,10 +98,10 @@ class MoistLapseRate(LapseRate):
 
         w_saturated = vmr2mixing_ratio(saturation_pressure(T) / p)
 
-        gamma_m = (gamma_d * ((1 + (L * w_saturated) / (Rd * T)) /
-                              (1 + (L**2 * w_saturated) / (Cp * Rv * T**2))
-                              )
-                   )
+        gamma_m = gamma_d * (
+            (1 + (L * w_saturated) / (Rd * T))
+            / (1 + (L ** 2 * w_saturated) / (Cp * Rv * T ** 2))
+        )
 
         return _to_p_coordinates(gamma_m, p, T)
 
@@ -107,6 +109,7 @@ class MoistLapseRate(LapseRate):
 class FixedLapseRate(LapseRate):
     """Fixed constant lapse rate through the whole atmosphere. Linear decrease
     in temperature with height."""
+
     def __init__(self, lapserate=0.0065):
         """
         Parameters:
@@ -120,6 +123,7 @@ class FixedLapseRate(LapseRate):
 
 class DryLapseRate(FixedLapseRate):
     """Fixed dry-adiabatic lapse rate through the whole atmosphere."""
+
     def __init__(self):
         g = constants.earth_standard_gravity
         c_p = constants.isobaric_mass_heat_capacity_dry_air


### PR DESCRIPTION
This PR:
* Replaces the former "fixed moist-adiabat" with an explicit lapse-rate cache.
   ```py
   # Old
   lapserate = konrad.lapserate.MoistLapseRate(fixed=True). # NO LONGER POSSIBLE
   
   # New
   lapserate = konrad.lapserate.MoistLapseRate()
   lapserate.build_cache(atmosphere)
   ```
* Lapse-rate classes return their values in pressure coordinates
* Add convenience class for dry-adiabatic lapse rate