### PR TITLE
Replace direct URL of CliMT with  PyPI version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'scipy>=0.19.0',
         'typhon>=0.7.0',
         'xarray>=0.9.1',
-        'climt @ https://api.github.com/repos/atmtools/climt/tarball/allow-latest-numpy',
+        'climt>=0.16.25',
         'sympl>=0.4.0',
     ],
     extras_require={


### PR DESCRIPTION
The PyPI does not allow pacakges to specify direct URLs anymore.