### PR TITLE
Fix setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Konrad depends on the [CliMT](https://github.com/CliMT/climt) package.
 CliMT handles a variety of underlying FORTRAN code and provides precompiled
 binary wheels for some Python versions and operating systems.
 
-### Python >3.7
-However, for Python >3.7 the FORTRAN libraries need to be compiled locally.
+However (for Python >3.7) the FORTRAN libraries need to be compiled locally.
 In this case, you need to specify a C compiler, a FORTRAN compiler, and the
 target architecture using the corresponding environment variables:
 ```bash
@@ -35,6 +34,6 @@ CC=gcc FC=gfortran TARGET=HASWELL pip install konrad
 ### macOS
 On macOS, you may need to install the GCC compiler suite beforehand:
 ```bash
-brew install gcc@10
-CC=gcc-10 FC=gfortran-10 TARGET=HASWELL pip install konrad
+brew install gcc@11
+CC=gcc-11 FC=gfortran-11 TARGET=ARMV8 python -m pip install git+https://github.com/atmtools/climt@rrtmg-only
 ```

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'scipy>=0.19.0',
         'typhon>=0.7.0',
         'xarray>=0.9.1',
-        'climt @ https://api.github.com/repos/atmtools/climt/tarball/allow-latest-numpy',
+        'climt>=0.16.25',
         'sympl>=0.4.0',
     ],
     extras_require={


### PR DESCRIPTION
This PR
* replaces the CliMT dependency with a version available on PyPI
* adds a description on how to retrieve said `climb` version on macOS