### PR TITLE
Make the call of `FixedTemperature` more verbose

### DIFF
--- a/howto/atmosphere.md
+++ b/howto/atmosphere.md
@@ -42,7 +42,7 @@ Next, we can compile and run our RCE simulation
 ```{code-cell} ipython3
 rce = konrad.RCE(
     atmosphere,
-    surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+    surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
     timestep='12h',  # Set timestep in model time.
     max_duration='100d',  # Set maximum runtime.
 )

--- a/howto/getting_started.md
+++ b/howto/getting_started.md
@@ -46,7 +46,7 @@ Next, we can compile the RCE object, which combines the different model componen
 # Initialize the setup for the radiative-convective equilibrium simulation.
 rce = konrad.RCE(
     atmosphere,
-    surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+    surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
     timestep='12h',  # Set timestep in model time.
     max_duration='100d',  # Set maximum runtime.
 )

--- a/howto/humidity.md
+++ b/howto/humidity.md
@@ -45,7 +45,7 @@ atmosphere = konrad.atmosphere.Atmosphere(phlev)
 
 rce = konrad.RCE(
     atmosphere,
-    surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+    surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
     humidity=humidity_model,  # Here, we pass the humidity component that we just created
     timestep='12h',  # Set timestep in model time.
     max_duration='150d',  # Set maximum runtime.
@@ -82,7 +82,7 @@ humidity_model = konrad.humidity.FixedVMR()  # Preserve the absolute humidity
 
 rce = konrad.RCE(
     atmosphere,
-    surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+    surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
     humidity=humidity_model,  # Here, we pass the humidity component that we just created
     timestep='12h',  # Set timestep in model time.
     max_duration='100d',  # Set maximum runtime.

--- a/howto/lapserate.md
+++ b/howto/lapserate.md
@@ -44,7 +44,7 @@ for lapserate in [6.5, 8, 10]:
 
     rce = konrad.RCE(
         atmosphere,
-        surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+        surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
         lapserate=lapserate,  # Here, we pass the lapserate component that we just created
         timestep='12h',  # Set timestep in model time.
         max_duration='100d',  # Set maximum runtime.
@@ -65,7 +65,7 @@ atmosphere = konrad.atmosphere.Atmosphere(phlev)
 
 rce = konrad.RCE(
     atmosphere,
-    surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+    surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
     lapserate=lapserate,  # Here, we pass the lapserate component that we just created
     timestep='12h',  # Set timestep in model time.
     max_duration='100d',  # Set maximum runtime.
@@ -93,7 +93,7 @@ fig, ax = plt.subplots()
 for Ts in [280, 290, 300]:
     rce = konrad.RCE(
         atmosphere,
-        surface=konrad.surface.FixedTemperature(Ts),  # Run with a fixed surface temperature.
+        surface=konrad.surface.FixedTemperature(temperature=Ts),  # Run with a fixed surface temperature.
         lapserate=konrad.lapserate.MoistLapseRate(),  # Here, we pass the lapserate component that we just created
         timestep='12h',  # Set timestep in model time.
         max_duration='100d',  # Set maximum runtime.

--- a/howto/netcdf_output.md
+++ b/howto/netcdf_output.md
@@ -33,7 +33,7 @@ atmosphere = konrad.atmosphere.Atmosphere(phlev)
 
 rce = konrad.RCE(
     atmosphere,
-    surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+    surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
     timestep='12h',  # Set timestep in model time.
     max_duration='100d',  # Set maximum runtime.
     outfile="my_rce_output.nc",  # Specifiy the output file

--- a/howto/surface.md
+++ b/howto/surface.md
@@ -31,7 +31,7 @@ The simplest representatio of a surface in `konrad` is the fixed surface tempera
 It is defined by an albedo and a prescribed temperature.
 
 ```{code-cell} ipython3
-surface = konrad.surface.FixedTemperature(288., albedo=0.3)
+surface = konrad.surface.FixedTemperature(temperature=288., albedo=0.3)
 ```
 
 When using a fixed surface temperature, the atmosphere component will converge to a consistent equilibrium quite fast (order of ~100 days)
@@ -42,7 +42,7 @@ atmosphere = konrad.atmosphere.Atmosphere(phlev)
 
 rce = konrad.RCE(
     atmosphere,
-    surface=konrad.surface.FixedTemperature(288.),  # Run with a fixed surface temperature.
+    surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
     timestep='12h',  # Set timestep in model time.
     max_duration='100d',  # Set maximum runtime.
 )


### PR DESCRIPTION
In addition to being more self-explaining, passing the surface
temperature as keyword argument also makes the call more robust for
older konrad versions.