### PR TITLE
Use convenience class for dry-adiabatic lapse rate

### DIFF
--- a/howto/lapserate.md
+++ b/howto/lapserate.md
@@ -66,7 +66,7 @@ atmosphere = konrad.atmosphere.Atmosphere(phlev)
 rce = konrad.RCE(
     atmosphere,
     surface=konrad.surface.FixedTemperature(temperature=288.),  # Run with a fixed surface temperature.
-    lapserate=lapserate,  # Here, we pass the lapserate component that we just created
+    lapserate=konrad.lapserate.DryLapseRate(),  # Run with dry adiabatic lapse rate
     timestep='12h',  # Set timestep in model time.
     max_duration='100d',  # Set maximum runtime.
 )


### PR DESCRIPTION
Pass a dry-adiabatic lapse rate component to the RCE object 
in the respective section instead of passing the lapse rate 
component created in the previous section