### PR TITLE
Suppress all warnings during climt import

### DIFF
--- a/konrad/radiation/rrtmg.py
+++ b/konrad/radiation/rrtmg.py
@@ -1,10 +1,15 @@
 """Define an interface for the RRTMG radiation scheme (through CliMT). """
+from contextlib import redirect_stdout, redirect_stderr
+import io
+
 from copy import deepcopy
 import numpy as np
 import datetime
 from sympl import DataArray
 from typhon.physics import vmr2specific_humidity
-import climt
+with redirect_stdout(io.StringIO()) as _, redirect_stderr(io.StringIO()) as _:
+    # Suppress warnings by climt which are created by logging and print statements.
+    import climt
 import logging
 
 from .radiation import Radiation


### PR DESCRIPTION
The climate module may through import errors for non-compiled models (e.g. simple physics, Emanuel convection). This PR introduces a workaround to silence these warning that are created by a mix of `logging` and plain `print` statements.