### PR TITLE
Add an actual test of an RCE simulation

### DIFF
--- a/konrad/test/test_rce.py
+++ b/konrad/test/test_rce.py
@@ -1,0 +1,24 @@
+from os.path import dirname, join
+
+import numpy as np
+import pytest
+
+from konrad import atmosphere, utils, RCE
+
+
+@pytest.fixture
+def atmosphere_obj():
+    _, phlev = utils.get_pressure_grids(surface_pressure=1000e2, num=50)
+
+    return atmosphere.Atmosphere(phlev=phlev)
+
+
+class TestRCE:
+    def test_init(self, atmosphere_obj):
+        """Test initialisation of an RCE simulation."""
+        RCE(atmosphere_obj)
+
+    def test_run(self, atmosphere_obj):
+        """Integrate an RCE simulation for four time steps.."""
+        rce = RCE(atmosphere_obj, timestep="12h", max_duration="48h")
+        rce.run()


### PR DESCRIPTION
This PR adds two test that check the actual integration of an RCE simulation. The simulation only runs for four time steps which should, however, be enough to capture most general issues.