### PR TITLE
Small fixes

### DIFF
--- a/konrad/aerosol.py
+++ b/konrad/aerosol.py
@@ -25,7 +25,8 @@ Create an instance of an aerosol class, *e.g.* a :py:class:`VolcanoAerosol`:
 
     >>> rrtmg.calc_radiation(atmosphere=..., surface=...,aerosol=aerosol)
 
-More input files for radiative properties of aerosols are available at #TODO
+More input files for radiative properties of aerosols are available at
+https://doi.org/10.5281/zenodo.8212074
 """
 
 import os

--- a/konrad/radiation/common.py
+++ b/konrad/radiation/common.py
@@ -7,7 +7,7 @@ def fluxes2heating(net_fluxes, pressure, cp=None, method="diff"):
     r"""Calculate radiative heating from net fluxes
 
     .. math::
-        Q_\mathrm{r} = \frac{F}{c_p} \frac{\mathrm{d}F}{\mathrm{d}p}
+        Q_\mathrm{r} = \frac{g}{c_p} \frac{\mathrm{d}F}{\mathrm{d}p}
 
     Parameters:
         net_fluxes (ndarray): Net radiative flux.


### PR DESCRIPTION
1. When we added the aerosol module, we forgot to add the zenodo link to download more aerosol profiles, I fixed this.
2. There was an error in the doc string for the fluxes2heating function, the pre-factor should be g/c_p, not F/c_p. In the code it's correct, only the docstring was wrong.